### PR TITLE
feat: modernized code and content

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Dieses Repository ist ein Fork der Seite http://drzoom.ch/project/dml/, die mitt
 
 Das Dokument kann mittels `latexmk -pdf diplomarbeit_mit_latex.tex` erstellt werden.
 
-"Diplomarbeit mit LaTeX" ist ein Dokument welches einen einfachen Einstieg in LaTeX unter Windows beschreibt. In der Anleitung wird die LaTeX-Distribution [MiKTeX](http://miktex.org/) beschrieben in Kombination mit der Umgebung [TeXnicCenter](http://www.texniccenter.org/).
+"Diplomarbeit mit LaTeX" ist ein Dokument welches einen einfachen Einstieg in LaTeX (primär unter Windows) beschreibt. In der Anleitung wird die LaTeX-Distribution [MiKTeX](https://miktex.org/) beschrieben in Kombination mit der Umgebung [TeXnicCenter](https://www.texniccenter.org/).
 
 Das Dokument soll einen schnellen Einstieg mit LaTeX ermöglichen. Ein kleines Tutorial führt dich Schritt für Schritt in die Materie ein.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
-# Diplomarbeit mit Latex
+# Diplomarbeit mit LaTeX
 
 Dieses Repository ist ein Fork der Seite http://drzoom.ch/project/dml/, die mittels https://web.archive.org/web/20080703042806/http://drzoom.ch/project/dml/ wiederhergestellt wurde.
 
 Das Dokument kann mittels `latexmk -pdf diplomarbeit_mit_latex.tex` erstellt werden.
 
-"Diplomarbeit mit LaTeX" ist ein Dokument welches einen einfachen Einstieg in Latex unter Windows beschreibt. In der Anleitung wird die LaTeX Distribution [MiKTeX](http://miktex.org/) beschrieben in kombination mit der Umgebung [TeXnicCenter](http://www.texniccenter.org/).
+"Diplomarbeit mit LaTeX" ist ein Dokument welches einen einfachen Einstieg in LaTeX unter Windows beschreibt. In der Anleitung wird die LaTeX-Distribution [MiKTeX](http://miktex.org/) beschrieben in Kombination mit der Umgebung [TeXnicCenter](http://www.texniccenter.org/).
 
-Das Dokument soll eine Hilfe sein, das du schnellen Start mit LaTeX hast. Ein kleines Turtorial führt dich Schritt für Schritt in die Materie ein.
+Das Dokument soll einen schnellen Einstieg mit LaTeX ermöglichen. Ein kleines Tutorial führt dich Schritt für Schritt in die Materie ein.
+
+## Vorarbeiten
+
+Damit das Dokument selbst mittels LaTeX erstellt kann, ist eine vorhergehende LaTeX-Installation erforderlich. Unter Debian sollte es reichen, folgende Pakete zu installieren:
+```
+sudo apt-get install latexmk texlive-fonts-recommended texlive-fonts-extra texlive-lang-german texlive-lang-french texlive-latex-base texlive-latex-extra texlive-latex-recommended texlive-science
+```

--- a/bib/references.bib
+++ b/bib/references.bib
@@ -18,18 +18,20 @@ Encoding: Cp1252
 }
 
 @BOOK{juergens:latex1,
-  title = {\LaTeX - eine Einführung und ein bisschen mehr ...},
+  title = {\LaTeX -- eine Einführung und ein bisschen mehr ...},
   year = {2000},
+  publisher = {FernUniversität in Hagen},
   author = {Manuela Jürgens},
   note = {\\ \href{ftp://ftp.fernuni-hagen.de/pub/pdf/urz-broschueren/broschueren/a026.pdf}{ftp://ftp.fernuni-hagen.de/pub/pdf/urz-broschueren/broschueren/a026.pdf}},
   institution = {FernUniversität Hagen}
 }
 
 @BOOK{juergens:latex2,
-  title = {\LaTeX - Fortgeschrittene Anwendungen},
-  year = {1995},
+  title = {\LaTeX -- Fortgeschrittene Anwendungen oder: Neues von den Hobbits},
+  year = {2016},
+  publisher = {FernUniversität in Hagen},
   author = {Manuela Jürgens},
-  note = {\\ \href{ftp://ftp.fernuni-hagen.de/pub/pdf/urz-broschueren/broschueren/a027.pdf}{ftp://ftp.fernuni-hagen.de/pub/pdf/urz-broschueren/broschueren/a027.pdf}},
+  note = {\\ \href{https://www.fernuni-hagen.de/imperia/md/content/zmi\_2010/a027\_latex\_fort.pdf}{www.fernuni-hagen.de/imperia/md/content/zmi\_2010/a027\_latex\_fort.pdf}},
   institution = {FernUniversität Hagen}
 }
 

--- a/bib/references.bib
+++ b/bib/references.bib
@@ -14,15 +14,15 @@ Encoding: Cp1252
 @MISC{fritsch:schreiben_fuer_die_Leser,
   author = {Claudia Fritsch},
   title = {Schreiben für die Leser},
-  url = {http://homepages.fh-giessen.de/~hg11260/mat/schreibmuster.pdf}
+  url = {https://esb-dev.github.io/mat/Schreibmuster.pdf}
 }
 
 @BOOK{juergens:latex1,
   title = {\LaTeX -- eine Einführung und ein bisschen mehr ...},
-  year = {2000},
+  year = {2017},
   publisher = {FernUniversität in Hagen},
-  author = {Manuela Jürgens},
-  note = {\\ \href{ftp://ftp.fernuni-hagen.de/pub/pdf/urz-broschueren/broschueren/a026.pdf}{ftp://ftp.fernuni-hagen.de/pub/pdf/urz-broschueren/broschueren/a026.pdf}},
+  author = {Manuela Jürgens, Thomas Feuerstack},
+  note = {\\ \href{https://www.fernuni-hagen.de/imperia/md/content/zmi\_2010/a026\_latex\_einf.pdf}{www.fernuni-hagen.de/imperia/md/content/zmi\_2010/a026\_latex\_einf.pdf}},
   institution = {FernUniversität Hagen}
 }
 
@@ -71,13 +71,13 @@ Encoding: Cp1252
 @MISC{WhatIsSpam,
   author = {Scott Hazen Mueller},
   title = {What is spam?},
-  note = {\href{http://spam.abuse.net/overview/whatisspam.shtml}{http://spam.abuse.net/overview/whatisspam.shtml}}
+  note = {\href{https://web.archive.org/web/20180403023743/http://spam.abuse.net:80/overview/whatisspam.shtml}{https://web.archive.org/web/20180403023743/http://spam.abuse.net:80/overview/whatisspam.shtml}}
 }
 
 @MISC{Kochbuch,
   author = {Markus Porto},
   title = {Kochbuch für LaTeX},
-  url = {http://www.uni-giessen.de/hrz/tex/cookbook/cookbook.html}
+  url = {https://web.archive.org/web/20060202005639/http://www.uni-giessen.de/hrz/tex/cookbook/cookbook.html}
 }
 
 @BOOKLET{raichle:bibtex_programmierung,
@@ -85,19 +85,19 @@ Encoding: Cp1252
   author = {Bernd Raichle},
   year = {2002},
   institution = {DANTE},
-  url = {http://www.dante.de/dante/events/dante2002/handouts/raichle-bibtexprog.pdf}
+  url = {https://www.sjmp.de/wp-content/uploads/2010/01/bibtexprog.pdf}
 }
 
 @MISC{TabSatz,
   author = {Axel Reichert},
   title = {Satz von {T}abellen},
-  note = {\\ \href{http://www.ctan.org/tex-archive/info/german/tabsatz/}{http://www.ctan.org/tex-archive/info/german/tabsatz/}}
+  note = {\\ \href{https://www.ctan.org/tex-archive/info/german/tabsatz/}{https://www.ctan.org/tex-archive/info/german/tabsatz/}}
 }
 
 @MISC{MiKTeX,
   author = {Christian Schenk},
   title = {{MiKTeX Project Page}},
-  note = {\href{http://www.miktex.org/}{http://www.miktex.org/}}
+  note = {\href{https://www.miktex.org/}{https://www.miktex.org/}}
 }
 
 @BOOK{schneider:deutsch_fuers_leben,
@@ -112,18 +112,12 @@ Encoding: Cp1252
 @MISC{TeXnicCenter,
   author = {Sven Wiegand},
   title = {{TeXnicCenter}},
-  url = {\href{http://www.TeXnicCenter.org/}{http://www.TeXnicCenter.org/}}
-}
-
-@MISC{Adobe,
-  title = {{Adobe Webseite}},
-  note = {\href{http://www.adobe.com/}{http://www.adobe.com/}},
-  key = {Adobe}
+  url = {\href{https://www.TeXnicCenter.org/}{https://www.TeXnicCenter.org/}}
 }
 
 @MISC{ANSI,
   title = {{American National Standards Institute}},
-  note = {\href{http://www.ansi.org/}{http://www.ansi.org/}},
+  note = {\href{https://www.ansi.org/}{https://www.ansi.org/}},
   key = {ANSI}
 }
 
@@ -135,13 +129,13 @@ Encoding: Cp1252
 
 @MISC{KOMA,
   title = {{\KOMAScript{} documentation project}},
-  note = {\href{http://koma-script.net.tf}{http://koma-script.net.tf}},
+  note = {\href{https://komascript.de}{https://komascript.de}},
   key = {KOMA}
 }
 
 @MISC{NoGIF,
   title = {{GNU Webseite zum Thema GIF Dateien}},
-  note = {\\ \href{http://www.gnu.org/philosophy/gif.de.html}{http://www.gnu.org/philosophy/gif.de.html}},
+  note = {\\ \href{https://www.gnu.org/philosophy/gif.de.html}{https://www.gnu.org/philosophy/gif.de.html}},
   key = {NoGIF}
 }
 
@@ -149,7 +143,7 @@ Encoding: Cp1252
   title = {{GNU} general public license},
   month = {jun},
   year = {1991},
-  note = {\href{http://www.gnu.org/licenses/gpl.txt}{http://www.gnu.org/licenses/gpl.txt}},
+  note = {\href{https://www.gnu.org/licenses/gpl.txt}{https://www.gnu.org/licenses/gpl.txt}},
   key = {GPL},
   organization = {Free Software Foundation, Inc.}
 }

--- a/chapters/aenderungen.tex
+++ b/chapters/aenderungen.tex
@@ -21,11 +21,13 @@
 			\item (te) Im Text \enquote{File} durch \enquote{Datei} ersetzt.
 			\item (te) Einen Hinweis zu fett gesetzten Texten ergänzt.
 			\item (te) Installation überprüft und Link zu MiKTeX installer angepasst.
-			\item (te) Kapitel \enquote{Literaturempfehlungen} überarbeitet. Sprache vereinfacht und Abschnitt über die Rechtschreibprüfung in das Kapitel \enquote{Konfiguration} verschoben. Buch \enquote{Der \DMLLaTeX \ Begleiter} hinzugefügt.
+			\item (te) Kapitel \enquote{Literaturempfehlungen} überarbeitet.
+				Sprache vereinfacht, Rechtschreibprüfungsabschnitt ins Konfigurationskapitel verschoben. 
+				Buch \enquote{Der \DMLLaTeX"=Begleiter} hinzugefügt.
 			\item (te) Kapitel \enquote{Mathematischer Textsatz} (vorher \enquote{Formeln}) überarbeitet.
 			\item (te) \enquote{header.tex} überarbeitet. Detailiertere Kommentare eingefügt und Optionen der Pakete angepasst oder verändert damit DML mit MiKTeX 2.6 optimal kompiliert werden kann.
 			\item (te) Statt einem richtigen @ Zeichen, \enquote{at} in die E-Mail Adressen im Titel engefügt. Da Spammer offensichtlich auch PDFs durchsuchen.
-			\item (te) Neue Umgebung \verb|\DMLLaTeX| und \verb|\DMLTeX| erstellt, welche unabhängig vom gewählten Font das \DMLLaTeX und \DMLTeX Logo korrekt setzen.
+			\item (te) Neue Umgebung \verb|\DMLLaTeX| und \verb|\DMLTeX| erstellt, welche unabhängig von der gewählten Schriftart das \DMLLaTeX- und das \DMLTeX"=Logo korrekt setzen.
 		\end{ListChanges}
 	\item[Version 1.11 / 2. April 2006]
 		\begin{ListChanges}
@@ -43,32 +45,32 @@
 	\item[Version 1.9 / 20. Oktober 2003]
 		\begin{ListChanges}
 			\item Kapitel \enquote{Deutsche Anführungszeichen einstellen} hinzugefügt (nach einer Mail von Christian Günther).
-			\item Unterschied zwischen schweizerischen und fran\-zösischen
-			Anführungszeichen im Abschnitt~\ref{sec:anfuehrungszeichen} hinzugefügt\\
+			\item Erklärung zur Unterscheidung von schweizerischen und französischen Anführungszeichen im Abschnitt~\ref{sec:anfuehrungszeichen} hinzugefügt\\
 			(nach einem Hinweis von Erich Hohermuth).
 			\item Im Abschnitt \ref{sec:erstesbeispiel} habe ich mehr zu der \enquote{T1} Codierung hinzugefügt (nach einer Mail von Christian Günther).
-			\item Ich habe überall die Zeile\\ \texttt{\textbackslash usepackage[german,ngerman]\{babel\}}
-			durch \texttt{\textbackslash usepackage\{ngerman\}} ersetzt (nach\\
-			einer Anregung von Christian Günther).
+			\item Ich habe überall die Zeile\\ 
+				\texttt{\textbackslash usepackage[german,ngerman]\{babel\}}\\
+				durch \texttt{\textbackslash usepackage\{ngerman\}} ersetzt (nach einer Anregung von Christian Günther).
 			\item In der Hauptdatei dieses Dokuments habe ich die \texttt{\textbackslash input} durch \texttt{\textbackslash include} Befehle ersetzt.
 			\item Im Kapitel \ref{sec:aufbaugrosserdokumente} habe ich in einem Abschnitt die Unterschiede zwischen \texttt{\textbackslash input} und \texttt{\textbackslash include} erklärt.
 		\end{ListChanges}
 	\item[Version 1.8 / 9. Februar 2003]
 		\begin{ListChanges}
-			\item Diverse Verbesserungen in der Rechtschreibung und Änderungen an der Formulierung im Kapitel~\ref{sec:installation} 
-			\\
-			(nach Anregungen von Christian Faulhammer).
-			\item Den Satzspiegel und die Schriftgröße verändert. Neu verwende ich die Vorgabe des \KOMAScript{} Pakets. Zudem ist die Schriftgröße 12 Punkte groß. Ich hoffe, dass dadurch das Dokument am Bildschirm besser lesbar ist.
+			\item Rechtschreibkorrekturen und Änderungen an der Formulierung im Kapitel~\ref{sec:installation}
+				(nach Anregungen von Christian Faulhammer)
+			\item Satzspiegel und die Schriftgröße verändert -- versucht, Vorgaben des \KOMAScript{}"=Pakets umzusetzen. 
+				Schriftgröße auf 12 Punkte erhöht. Ich hoffe, dass dadurch das Dokument am Bildschirm besser lesbar ist.
 			\item Backslash korrigiert. Statt \texttt{\$\textbackslash backslash\$} verwende ich nun überall \texttt{\textbackslash textbackslash}.
 			\item Den Link zu der \KOMAScript{} Webseite korrigiert.
 			\item Den Ausdruck KOMA-Script an allen Stellen im Dokument durch \KOMAScript{} ersetzt.
 			\item Jedes \enquote{z.B} durch \enquote{z.\,B.} ersetzt.
 			\item Die \enquote{center} Umgebung bei Tabellen\\ und Grafiken durch \texttt{\textbackslash centering} ersetzt.
 			\item Hinweis auf das Dokument \enquote{tabsatz} im Abschnitt \ref{sec:linienintabellen} eingefügt.
-			\item Hinweis zu \DMLLaTeX-WYSIWYG Programmen im Kapitel \ref{sec:motivation}
+			\item Hinweis zu WYSIWYG"=Programmen im Kapitel \ref{sec:motivation}
 			\item Kapitel \enquote{Dokumentklassen} um zwei Kapitel vorgezogen.
-			\item Alle Dokumentklassen direkt durch\\ \KOMAScript{}-Dokument~-klassen ersetzt. Da es sich hier um eine deutsche Dokumentation handelt, habe ich mich dafür entschieden, direkt die \KOMAScript{}-Dokument\-klassen\\
-einzuführen. Diese sind für Anfänger wesentlich besser geeignet und bieten mehr Optionen.
+			\item Alle Dokumentklassen direkt durch \KOMAScript{}"=Dokumentklassen ersetzt. 
+				Da es sich um eine deutsche Dokumentation handelt, führe ich direkt die \KOMAScript{}"=Dokumentklassen ein. 
+				Diese sind für Anfänger wesentlich besser geeignet und bieten mehr Optionen.
 			\item Den Hinweis für einen europäischen Absatz geändert, und die Klassenoptionen\\
 			 von \KOMAScript{} eingefügt.
 			\item Das Paket \enquote{pslatex} durch \enquote{mathptmx},\\

--- a/chapters/aenderungen.tex
+++ b/chapters/aenderungen.tex
@@ -10,7 +10,7 @@
 \label{sec:aendeungen}
 
 \begin{labeling}{(MMM)}
-	\item[(te)] Tobias Erbsland (inklusive alle Eintrage ohne Namen)
+	\item[(te)] Tobias Erbsland (inklusive aller Einträge ohne Namen)
 	\item[(an)] Andreas Nitsch
 \end{labeling}
 

--- a/chapters/aenderungen.tex
+++ b/chapters/aenderungen.tex
@@ -12,13 +12,14 @@
 \begin{labeling}{(MMM)}
 	\item[(te)] Tobias Erbsland (inklusive aller Einträge ohne Namen)
 	\item[(an)] Andreas Nitsch
+	\item[(se)] seth
 \end{labeling}
 
 
 \begin{labeling}{Version 99.99 / 99. September 9999} % Spez. komascript Umgebung
 	\item[Version 1.12.1 / 25. Juli 2020]
 		\begin{ListChanges}
-			\item Einige veraltete LaTeX-Konstrukte modernisiert
+		\item (se) Einige veraltete LaTeX-Konstrukte modernisiert, Links aktualisiert, over-/underfull Boxes aufgelöst, Eingangskapitel aktualisiert, kleinere Korrekturen 
 		\end{ListChanges}
 	\item[Version 1.12 / 29. Februar 2008]
 		\begin{ListChanges}

--- a/chapters/aenderungen.tex
+++ b/chapters/aenderungen.tex
@@ -16,6 +16,10 @@
 
 
 \begin{labeling}{Version 99.99 / 99. September 9999} % Spez. komascript Umgebung
+	\item[Version 1.12.1 / 25. Juli 2020]
+		\begin{ListChanges}
+			\item Einige veraltete LaTeX-Konstrukte modernisiert
+		\end{ListChanges}
 	\item[Version 1.12 / 29. Februar 2008]
 		\begin{ListChanges}
 			\item (te) Im Text \enquote{File} durch \enquote{Datei} ersetzt.

--- a/chapters/ausstehendes.tex
+++ b/chapters/ausstehendes.tex
@@ -44,7 +44,7 @@ Für die folgenden Aufgaben suche ich noch Leute, die mich unterstützen. Kontakti
 	\item Es fehlen auch noch viele andere Kapitel. Vielleicht möchtest du ja noch eines schreiben.
 \end{itemize}
 
-Über die URL \href{https://secure.drzoom.ch/svn/dml}{https://secure.drzoom.ch/svn/dml} kannst du mit \enquote{Subversion} jederzeit die Quellen der aktuellste Version des Dokuments holen und deine Änderungen einarbeiten. Um deine Änderungen hochzuladen, benötigst du einen Account. Diesen bekommst du bei mir (Tobias). Schreib mir dazu einfach ein Mail, beschreib kurz was du gerne hinzufügen möchtest und wie dein Accountname heissen soll. Die SVN-URL steht nicht auf der Website, um unnötigen Traffic durch Spider zu vermeiden.
+Über die URL \href{https://secure.drzoom.ch/svn/dml}{https://secure.drzoom.ch/svn/dml} kannst du mit \enquote{Subversion} jederzeit die Quellen der aktuellste Version des Dokuments holen und deine Änderungen einarbeiten. Um deine Änderungen hochzuladen, benötigst du einen Account. Diesen bekommst du bei mir (Tobias). Schreib mir dazu einfach ein Mail, beschreib kurz was du gerne hinzufügen möchtest und wie dein Accountname heissen soll.
 
 Ein guter Subversion Client für Windows ist \href{http://tortoisesvn.tigris.org/}{\enquote{TortoiseSVN}}. Weitere Informationen über Subversion findest du im \href{http://svnbook.red-bean.com/}{\enquote{Subversion Book}}.
 

--- a/chapters/dokumentklassen.tex
+++ b/chapters/dokumentklassen.tex
@@ -247,7 +247,16 @@ Mit der Dokumentklasse \enquote{scrbook} werden die größten Dokumente erstellt. 
 
 Neu hinzu kommt der Befehl \texttt{\textbackslash part}, mit welchem du dein Buch in einzelne Teile unterteilen kannst.
 
-Mögliche Gliederungen in dieser Dokumentklasse sind \texttt{\textbackslash part}, \texttt{\textbackslash chapter}, \texttt{\textbackslash section}, \texttt{\textbackslash subsection}, \texttt{\textbackslash subsubsection}, \texttt{\textbackslash paragraph} und \texttt{\textbackslash subparagraph}.
+Mögliche Gliederungen in dieser Dokumentklasse sind:
+\begin{itemize}
+	\item \texttt{\textbackslash part}
+	\item \texttt{\textbackslash chapter}
+	\item \texttt{\textbackslash section}
+	\item \texttt{\textbackslash subsection}
+	\item \texttt{\textbackslash subsubsection}
+	\item \texttt{\textbackslash paragraph}
+	\item \texttt{\textbackslash subparagraph}.
+\end{itemize}
 
 Das Beispiellisting \ref{lst:book} erzeugt neun Seiten, welche du auf Abbildung \ref{fig:book} siehst.
 

--- a/chapters/dokumentklassen.tex
+++ b/chapters/dokumentklassen.tex
@@ -12,7 +12,7 @@
 
 Das grundsätzliche Layout eines \DMLLaTeX-Dokuments wird durch verschiedene Dokumentklassen bestimmt. Es existieren verschiedenste Pakete, welche weitere Dokumentklassen zu den Standardklassen hinzufügen.
 
-Eine interessante Erweiterung von \DMLLaTeX, welche für dieses Dokument verwendet wurde, ist \KOMAScript~\cite{KOMA}\index{KOMA-Script@\KOMAScript}. Wir beschreiben daher von Anfang an den Aufbau mit den \KOMAScript-Klassen. Sie bieten eine Vielzahl von Optionen und einer Anpassung der Standardklassen an die europäische Typographie.
+Eine empfehlenswerte Erweiterung von \DMLLaTeX, welche für auch für das vorliegende Dokument verwendet wurde, ist \KOMAScript~\cite{KOMA}\index{KOMA-Script@\KOMAScript}. Wir beschreiben daher von Anfang an den Aufbau mit den \KOMAScript-Klassen. Sie bieten eine Vielzahl von Optionen und einer Anpassung der Standardklassen an die europäische Typographie.
 
 Hier beschreibe ich die drei am häufigsten verwendeten Klassen und die wichtigsten Unterschiede zwischen diesen.
 
@@ -24,7 +24,7 @@ Pro Dokument kann nur eine Dokumentklasse definiert werden. Diese Deklaration mu
 \documentclass[Optionen]{Name der Klasse}
 \end{lstlisting}
 
-Es existieren dabei verschiedenste Optionen, welche sich auf das Layout des Dokuments auswirken. Sie sind weiter unten im Abschnitt \ref{sec:globaleoptionen} beschrieben und werden auch an alle folgenden \texttt{\textbackslash usepackage} Befehle weitergegeben. 
+Es existieren dabei verschiedenste Optionen, welche sich auf das Layout des Dokuments auswirken. Sie sind weiter unten im Abschnitt \ref{sec:globaleoptionen} beschrieben und werden auch an alle folgenden \texttt{\textbackslash usepackage}"=Befehle weitergegeben. 
 
 Wenn du bei der Dokumentklasse als Option z.\,B. \enquote{pdftex} angibst, wird diese Option auch an den Befehl \texttt{\textbackslash usepackage\{graphicx\}} weitergegeben. Dort musst du diese Option nicht mehr angeben.
 

--- a/chapters/dokumentteile.tex
+++ b/chapters/dokumentteile.tex
@@ -30,7 +30,7 @@ Dabei setzt man im Header oder zumindest vor dem Befehl die notwendigen Angaben:
 \begin{lstlisting}
 \title{Diplomarbeit}
 \author{Hans Muster}
-\date{12.12.2005} % optional
+\date{2005-12-12} % optional
 
 \maketitle
 \end{lstlisting}
@@ -85,7 +85,7 @@ Inhaltsverzeichnisse werden in \DMLLaTeX \ automatisch erzeugt. Es ist möglich e
 
 \DMLLaTeX \ geht dabei folgendermaßen vor: beim ersten Durchlauf werden die Seitennummern und Titel aller relevanten Überschriften und Beschriftungen in einer separaten Datei gespeichert (.aux). Aus dieser Datei werden am Schluss einzelne Dateien mit den verschiedenen Inhaltsverzeichnissen erstellt (.toc, .lot, .lof).
 
-Beim nächsten Durchlauf werden diese Dateien für das Inhaltsverzeichnis und die anderen Verzeichnisse verwendet. Da sich die Seitennummerierung dadurch verändern kann (weil z.B. das Inhaltsverzeichnis um fünf Zeilen wächst), wird evtl. ein weiterer Durchlauf notwendig.
+Beim nächsten Durchlauf werden diese Dateien für das Inhaltsverzeichnis und die anderen Verzeichnisse verwendet. Da sich die Seitennummerierung dadurch verändern kann (weil z.\,B. das Inhaltsverzeichnis um fünf Zeilen wächst), wird evtl. ein weiterer Durchlauf notwendig.
 
 Die Seitenverweise sind daher frühestens nach dem zweiten oder sogar dritten Durchlauf des Dokuments korrekt. Bevor du also die endgültige Fassung deines Dokuments erstellst, solltest du das Dokument sooft kompilieren, bis keine Warnungen wie die folgende mehr auftreten:
 
@@ -135,7 +135,7 @@ Die beiden Verzeichnisse kannst du folgendermaßen in dein Dokument einbetten:
 \section{Anhang}
 \index{Anhang}
 
-Oft hat ein Dokument noch Anhänge. Das sind Kapitel oder Anschnitte, welche zusätzliche Informationen zu dem Thema des Dokuments erhalten, z.B. Tabellen, Diagramme oder große Grafiken, welche oft aus dem Dokument referenziert werden, jedoch nicht in ein bestimmtes Kapitel des Dokuments passen. Ein Beispiel hierfür ist die API-Referenz einer Software.
+Oft hat ein Dokument noch Anhänge. Das sind Kapitel oder Anschnitte, welche zusätzliche Informationen zu dem Thema des Dokuments erhalten, z.\,B. Tabellen, Diagramme oder große Grafiken, welche oft aus dem Dokument referenziert werden, jedoch nicht in ein bestimmtes Kapitel des Dokuments passen. Ein Beispiel hierfür ist die API-Referenz einer Software.
 
 Der Anhang wird mit dem Befehl \texttt{\textbackslash appendix}\index{appendix@\texttt{\textbackslash appendix}} eingeleitet. Nach diesem Befehl werden die Kapitel oder Abschnitte mit Großbuchstaben nummeriert.
 

--- a/chapters/fdl.tex
+++ b/chapters/fdl.tex
@@ -364,7 +364,7 @@ The Free Software Foundation may publish new, revised versions
 of the GNU Free Documentation License from time to time.  Such new
 versions will be similar in spirit to the present version, but may
 differ in detail to address new problems or concerns.\\
-See http://www.gnu.org/copyleft/.
+See https://www.gnu.org/copyleft/.
 
 Each version of the License is given a distinguishing version number.
 If the Document specifies that a particular numbered version of this

--- a/chapters/formeln.tex
+++ b/chapters/formeln.tex
@@ -19,22 +19,22 @@ In \DMLLaTeX \ ist eine sehr mächtige Mathematik-Umgebung integriert, mit welche
 \end{equation}
 an dem du erahnen kannst, was möglich ist.
 
-Da das Setzen mathematischer Formeln ein Thema ist, welches allein mehrere Bücher füllen kann, möchte ich dir in diesem Kapitel nur einige wichtige Kommandos zeigen. Weitere Informationen findest du also in Büchern oder im Internet. Neben einigen Manuals, die im Folgenden genannt sind, ist als Nachschlagewerk die umfangreiche und mit Beispielen ausgestattete \TeX-Hilfe der Wikipedia\footnote{\href{http://de.wikipedia.org/wiki/Hilfe:TeX}{http://de.wikipedia.org/wiki/Hilfe:TeX}} zu empfehlen. Sie ist zwar eigentlich für den wikipedia-internen Formelsatz gedacht, aber in den meisten Fällen auch fürs konventionelle \TeX{}en sehr hilfreich.
+Da das Setzen mathematischer Formeln ein Thema ist, welches allein mehrere Bücher füllen kann, möchte ich dir in diesem Kapitel nur einige wichtige Kommandos zeigen. Weitere Informationen findest du also in Büchern oder im Internet. Neben einigen Manuals, die im Folgenden genannt sind, ist als Nachschlagewerk die umfangreiche und mit Beispielen ausgestattete \TeX-Hilfe der Wikipedia\footnote{\href{https://de.wikipedia.org/wiki/Hilfe:TeX}{https://de.wikipedia.org/wiki/Hilfe:TeX}} zu empfehlen. Sie ist zwar eigentlich für den wikipedia-internen Formelsatz gedacht, aber in den meisten Fällen auch fürs konventionelle \TeX{}en sehr hilfreich.
 
 Einige wichtige Symbole und Konstrukte kannst du über das Menü \enquote{Mathe} von TeXnicCenter direkt in deinen Quelltext einfügen. Jedoch hinkt dieses Menü den modernen mathematischen Packages teilweise hinterher, weshalb es geschickter ist, sich die neuesten Manuals aus dem Internet herunterzuladen und zu studieren.
 
-Wenn du komplexere Formeln in deinem Dokument verwendest oder viele mathematische Formeln benötigst, solltest du die Pakete der American Mathematical Society (kurz: \AmS) einbinden und deren relativ kurzgehaltene Manuals lesen. Die \AmSmath-Packages stellen weitere Symbole und spezielle mathematische Umgebungen bereit. Eine detaillierte Erklärung zu den Packages bietet die \AmS\ auf ihrer Website sowie das CTAN.\footnote{Der URL des {\rmfamily\LaTeX}-Teils der Website der \AmS\ lautet \href{http://www.ams.org/tex/amslatex.html}{http://www.ams.org/tex/amslatex.html}; im CTAN, genauer auf \href{http://www.ctan.org/tex-archive/macros/latex/required/amslatex/}{http://www.ctan.org/tex-archive/macros/latex/required/amslatex/} sind ebenfalls kurze Infos zu den einzelnen Packages abrufbar.} Eingebunden werden die Packages beispielsweise durch
+Wenn du komplexere Formeln in deinem Dokument verwendest oder viele mathematische Formeln benötigst, solltest du die Pakete der American Mathematical Society (kurz: \AmS) einbinden und deren relativ kurzgehaltene Manuals lesen. Die \AmSmath-Packages stellen weitere Symbole und spezielle mathematische Umgebungen bereit. Eine detaillierte Erklärung zu den Packages bietet die \AmS\ auf ihrer Website sowie das CTAN.\footnote{Der URL des {\rmfamily\LaTeX}-Teils der Website der \AmS\ lautet \href{https://www.ams.org/tex/amslatex.html}{https://www.ams.org/tex/amslatex.html}; im CTAN, genauer auf \href{https://www.ctan.org/pkg/amslatex}{https://www.ctan.org/pkg/amslatex} sind ebenfalls kurze Infos zu den einzelnen Packages abrufbar.} Eingebunden werden die Packages beispielsweise durch
 
 \begin{lstlisting}
 \usepackage{amsmath, amsthm, amssymb}
 \usepackage{mathtools}
 \end{lstlisting}
 
-Empfehlenswert ist das im Beispiel zuletzt genannte Package \enquote{mathtools}, eine sehr nützliche Erweiterung der \AmSmath-Packages.\footnote{\href{http://texcatalogue.sarovar.org/entries/mathtools.html}{http://texcatalogue.sarovar.org/entries/mathtools.html}}
+Empfehlenswert ist das im Beispiel zuletzt genannte Package \enquote{mathtools}, eine sehr nützliche Erweiterung der \AmSmath-Packages.\footnote{\href{https://www.ctan.org/pkg/mathtools}{https://www.ctan.org/pkg/mathtools}}
 
-Wer sich intensiv mit mathematischen Formeln rumschlagen will, dem wird das Dokument Mathmode\footnote{\href{http://www.ctan.org/tex-archive/info/math/voss/mathmode/Mathmode.pdf}{http://www.ctan.org/tex-archive/info/math/voss/mathmode/Mathmode.pdf}} sehr hilfreich sein. Es geht auf viele Feinheiten ein, die z.\,B. in den \AmSmath-Manuals nicht oder nur sehr kurz abgehandelt werden.
+Wer sich intensiv mit mathematischen Formeln rumschlagen will, dem wird das Dokument Mathmode\footnote{\href{https://www.ctan.org/pkg/voss-mathmode}{https://www.ctan.org/pkg/voss-mathmode}} sehr hilfreich sein. Es geht auf viele Feinheiten ein, die z.\,B. in den \AmSmath-Manuals nicht oder nur sehr kurz abgehandelt werden.
 
-Mit diesen Packages sollte man auch für mathematische Diplomarbeiten -- zumindest bzgl. des Formelsatzes -- gerüstet sein.
+Mit diesen Packages sollte man auch für mathematische Abschlussarbeiten -- zumindest bzgl. des Formelsatzes -- gerüstet sein.
 
 \section{Die Gleichungsumgebungen}
 \subsection{Einbettung in Text}
@@ -114,7 +114,7 @@ Du kannst die Form \texttt{\textbackslash begin\{align*\}} verwenden, wenn du ke
 
 \section{Hoch- und tiefgestellte Ausdrücke}
 
-Einzelne Zeichen kannst du direkt mit einem \texttt{\^} oder \texttt{\_} Zeichen hoch- oder tiefstellen. Um mehrere Zeichen oder komplexe Ausdrücke hoch- oder tiefzustellen, musst du jene in geschweifte Klammern \texttt{\{\}} %ohne umgebende () ist {} besser lesbar
+Einzelne Zeichen kannst du direkt mit einem Zirkumflex (\texttt{\^}) oder einem Unterstrich (\texttt{\_}) hoch- bzw. tiefstellen. Um mehrere Zeichen oder komplexe Ausdrücke hoch- oder tiefzustellen, musst du jene in geschweifte Klammern \texttt{\{\}} %ohne umgebende () ist {} besser lesbar
 einschließen.
 
 %durch fortlaufende Nummern + Buchstaben (statt wiederkehrend dieselben) wird es für Leser leichter, die einzelnen Bsp voneinander zu trennen [anmerkung von seth: das halt' ich fuer'n geruecht. abgesehen davon, soll hier imho gar nix getrennt werden, ist doch immer dasselbe...]
@@ -259,7 +259,7 @@ Ausgespuckt wird hiermit
 	\lg 12.
 \end{equation}
 
-Es können jedoch im Header auch eigene Operatoren definiert, z.B.
+Es können jedoch im Header auch eigene Operatoren definiert, z.\,B.
 \begin{lstlisting}
 \DeclareMathOperator{\rg}{Rang}
 \DeclareMathOperator{\dom}{dom}
@@ -427,7 +427,7 @@ Die Symbole werden folgendermaßen dargestellt:
 	\blacksquare \quad \square 
 \end{equation}
 
-Eine sehr umfangreiche Liste von Symbolen bietet die \enquote{The Comprehensive \DMLLaTeX \ Symbol List}\footnote{\href{http://www.ctan.org/tex-archive/info/symbols/comprehensive/symbols-letter.pdf}{http://www.ctan.org/tex-archive/info/symbols/comprehensive/symbols-letter.pdf}}.
+Eine sehr umfangreiche Liste von Symbolen bietet die \enquote{The Comprehensive \DMLLaTeX \ Symbol List}\footnote{\href{https://www.ctan.org/pkg/comprehensive}{https://www.ctan.org/pkg/comprehensive}}.
 
 \section{Matrizen}
 Für Matrizen stehen verschiedene Umgebungen zur Verfügung. Da jene aber alle sehr ähnlich sind, möchte ich hier auf bloß eine, nämlich \enquote{pmatrix}, anhand eines Beispiels eingehen. Wie bei Tabellen werden Spalten mit dem Und-Zeichen und Zeilen mit zwei Backslashes separiert.
@@ -472,7 +472,7 @@ Code            & Darstellung & Kommentar\\
 \end{tabular}
 
 \subsection{Kursiv oder nicht?}
-Es führt regelmäßig zu Auseinandersetzungen, ob das Differential-d nun kursiv $\int xdx$ gesetzt werden soll oder nicht $\int x\mathrm dx$. Es hängt unter anderem davon ab, ob man das Differential-d nun als Operator -- und jene werden meist nicht kursiv gesetzt --, oder ob man traditionell $dx$ als eine Variable ansieht. Ähnlich sieht es beispielsweise bei der eulerschen Zahl $e$ aus, die man als Konstante oder als Funktion ansehen kann. Ich werde hier keine Schreibweise propagieren, aber wenigstens auf die Unterschiede hinweisen. Richtig sind ja letztendlich beide Schreibweisen, denn beide werden verstanden.
+Es führt regelmäßig zu Auseinandersetzungen, ob das Differential-d nun kursiv $\int xdx$ gesetzt werden soll oder nicht $\int x\mathrm dx$. Es hängt unter anderem davon ab, ob man das Differential-d nun als Operator -- und jene werden meist nicht kursiv gesetzt -- oder ob man traditionell $dx$ als eine Variable ansieht. Ähnlich sieht es beispielsweise bei der eulerschen Zahl $e$ aus, die man als Konstante oder als Funktion ansehen kann. Ich werde hier keine Schreibweise propagieren, aber wenigstens auf die Unterschiede hinweisen. Richtig sind ja letztendlich beide Schreibweisen, denn beide werden verstanden.
 
 \begin{lstlisting}
 \begin{equation*}
@@ -500,13 +500,13 @@ Je nach Geschmack werden auch vor den Differential-ds schmale Leerräume eingefüg
 Traditionell werden einige Mengen, beispielsweise die der natürlichen oder der reellen Zahlen mit einem fetten lateinischen Majuskel symbolisiert. Da sich auf Tafeln (engl. \emph{blackboard}) so schlecht fett schreiben lässt, hat es sich eingebürgert, die Großbuchstaben mit einem Doppelstrich zu versehen. Dies wurde auch im Druck übernommen. Allerdings sind die in \TeX weitverbreiteten \verb|\mathbb|-Symbole eigentlich nicht völlig authentisch, da sie andere Doppelstriche beifügen. Abhilfe schafft hier das package \enquote{dsfont}. Am Beispielcode
 \begin{lstlisting}
 \begin{gather*}
-	\mathbb N  \mathbb Z  \mathbb Q  \mathbb R  \mathbb C  \mathbb P\\
+	\mathbb N \mathbb Z \mathbb Q \mathbb R \mathbb C \mathbb P\\
 	\mathds N \mathds Z \mathds Q \mathds R \mathds C \mathds P
 \end{gather*}
 \end{lstlisting}
 und dem übersetzten Analogon
 \begin{gather*}
-	\mathbb N  \mathbb Z  \mathbb Q  \mathbb R  \mathbb C  \mathbb P\\
+	\mathbb N \mathbb Z \mathbb Q \mathbb R \mathbb C \mathbb P\\
 	\mathds N \mathds Z \mathds Q \mathds R \mathds C \mathds P
 \end{gather*}
 soll dieser Unterschied deutlich werden.
@@ -557,7 +557,7 @@ Nach diesem aufregenden Beispiel nun eine hübschere Variante:
 	ergibt.
 \end{quote}
 
-Man sieht hier u.\,a., dass hinter Formeln auch Punkte und Kommas gesetzt werden.
+Man sieht hier unter anderem, dass hinter Formeln auch Punkte und Kommas gesetzt werden.
 %
 % EOF
 %

--- a/chapters/glossar.tex
+++ b/chapters/glossar.tex
@@ -71,11 +71,10 @@ Neben der Änderung der Glossarüberschrift gibt es noch weitere Einstellungen, mi
 Aussehen des Glossars beeinflussen kann. Folgende Einstellungen können im Header vorgenommen
 (s. Listing \ref{subsec:header}) werden und bestimmen, wie das glossary-Paket angewendet wird:
 
-\begin{tabular}{ll}
+\begin{tabularx}{\textwidth}{lX}
 			style &Der Glossar-Stil. Mögliche Werte sind:\\
 						&\textbf{list}: stellt Begriffe (fettgedruckt) und Erklärung in einer Zeile dar.\\
-						&\textbf{altlist}: stellt den Begriff fettgedruckt dar, Erklärung folgt versetzt auf der\\
-														   &nächsten Zeile\\
+						&\textbf{altlist}: stellt den Begriff fettgedruckt dar, Erklärung folgt versetzt auf der nächsten Zeile\\
 						&\textbf{super}: nutzt die \texttt{supertabular}- Umgebung für das Glossar.\\
 						&\textbf{long}: nutzt die \texttt{longtable}- Umgebung für das Glossar (default).\\
 			header &Setzt die Überschriften der Begriffs- und Erklärungsspalten. Mögliche Werte sind:\\
@@ -84,12 +83,9 @@ Aussehen des Glossars beeinflussen kann. Folgende Einstellungen können im Header
 		  border &Rahmen um das Glossar. Mögliche Werte sind:\\
 		  			&\textbf{none}: Glossar ist nicht eingerahmt (default).\\
 		  			&\textbf{plain}: Körper des Glossars wird eingerahmt.\\		  
-% Die folgenden Zeilen wurden ohne \\ nicht umbrochen, sondern gingen 314pt über den Seitenrand hinaus! :-( 
-			cols	& Anzahl der Spalten des Glossars. Mögliche Werte sind: \\ 
-						&\textbf{2}: Die Begriffsbezeichnung ist in der ersten, Erklärung und zugehörige Seitenzahl \\
- 						   					&in der zweiten Glossarspalte (default). \\ 
-						&\textbf{3}: Die Begriffsbezeichnung ist in der ersten, die Erklärung in der zweiten und die \\
- 							 					&zugehörigen Seitenzahlen in der dritten Glossarspalte. \\ 
+			cols	& Anzahl der Spalten des Glossars. Mögliche Werte sind:\\ 
+						&\textbf{2}: Die Begriffsbezeichnung ist in der ersten, Erklärung und zugehörige Seitenzahl in der zweiten Glossarspalte (default).\\ 
+						&\textbf{3}: Die Begriffsbezeichnung ist in der ersten, die Erklärung in der zweiten und die zugehörigen Seitenzahlen in der dritten Glossarspalte.\\
 		  number &Die jedem Eintrag zugeordnete Nummerierung. Nummerierungen können sein:\\
 		  			&\textbf{page}: jedem Eintrag sind/ist die zugehörige(n) Seitenzahl(en) zugeordnet (default).\\
 		  			&\textbf{section}: jedem Eintrag sind/ist die zugehörige(n) Kapitelnummer(n) zugeordnet.\\
@@ -97,10 +93,9 @@ Aussehen des Glossars beeinflussen kann. Folgende Einstellungen können im Header
 		  toc &Legt fest, ob das Glossar in das Inhaltsverzeichnis aufgenommen werden soll:\\
 		  		&\textbf{true}: fügt das Glossar zum Inhaltsverzeichnis hinzu.\\
 		  		&\textbf{false}: fügt das Glossar nicht zum Inhaltsverzeichnis hinzu.
-\end{tabular}
+\end{tabularx}
 \vspace{1em}
 \\
-Weitere Möglichkeiten Glossare nach eigenen Vorstellungen zu gestalten finden sich im
-Dokument ''glossary.dvi - glossary.sty: \DMLLaTeX \ Package to Assist Generating Glossaries''
-\footnote{Dieses Dokument befindet sich im Mik\TeX-Verzeichnis im Unterverzeichnis /miktex/doc/latex/glossary.}. Als durchaus optisch ansprechend und übersichtlich haben sich
-die Glossar- Einstellungen erwiesen, wie sie im Beispiellisting \ref{subsec:header} angeführt sind.
+Weitere Möglichkeiten, Glossare nach eigenen Vorstellungen zu gestalten, finden sich im
+Dokument ''glossary.dvi -- glossary.sty: \DMLLaTeX \ Package to Assist Generating Glossaries''\footnote{Dieses Dokument befindet sich im Mik\TeX"=Verzeichnis: \verb~/miktex/doc/latex/glossary~.}. 
+Als durchaus optisch ansprechend und übersichtlich haben sich die Glossar"=Einstellungen erwiesen, wie sie im Beispiellisting \ref{subsec:header} angeführt sind.

--- a/chapters/grossedokumente.tex
+++ b/chapters/grossedokumente.tex
@@ -9,9 +9,9 @@
 \chapter{Aufbau großer Dokumente}
 \label{sec:aufbaugrosserdokumente}
 
-Bei großen Dokumenten geht schnell der Überblick verloren. Deshalb solltest du dein Dokument in einzelne Dateien aufteilen. Dazu steht dir der Befehl \texttt{\textbackslash include} und \texttt{\textbackslash input} zur Verfügung, mit welchen du eine weitere Datei an dieser Stelle einbinden kannst.
+Bei großen Dokumenten geht schnell der Überblick verloren. Eine Möglichkeit, etwas Struktur reinzubringen, ist, dassdu dein Dokument in einzelne Dateien aufteilst. Dazu stehen dir die Befehle \texttt{\textbackslash include} und \texttt{\textbackslash input} zur Verfügung, mit welchen du eine weitere Datei an dieser Stelle einbinden kannst.
 
-TeXnicCenter unterstützt dich bereits darin, indem er für dein Projekt ein eigenes Unterverzeichnis anlegt. Ich gehe in den folgenden Beispielen davon aus, dass du eine Diplomarbeit zu einem Onlineshop schreibst. Beim Erstellen von deinem TeXnicCenter Projekt (siehe dazu Kapitel \ref{sec:erstellenneuesprojekt} auf Seite \pageref{sec:erstellenneuesprojekt}) gibst du also als Projektname \enquote{onlineshop} an. TeXnicCenter erstellt dir dann in dem gewählen Unterverzeichnis ein Verzeichnis mit dem Namen \enquote{onlineshop} und legt darin die Datei \enquote{onlineshop.tex} an. Diese Datei definiert TeXnicCenter automatisch auch als Hauptdatei.
+TeXnicCenter unterstützt dich bereits darin, indem er für dein Projekt ein eigenes Unterverzeichnis anlegt. Ich gehe in den folgenden Beispielen davon aus, dass du eine Abschlussarbeit zu einem Onlineshop schreibst. Beim Erstellen von deinem TeXnicCenter"=Projekt (siehe dazu Kapitel \ref{sec:erstellenneuesprojekt} auf Seite \pageref{sec:erstellenneuesprojekt}) gibst du also als Projektname \enquote{onlineshop} an. TeXnicCenter erstellt dir dann in dem gewählen Unterverzeichnis ein Verzeichnis mit dem Namen \enquote{onlineshop} und legt darin die Datei \enquote{onlineshop.tex} an. Diese Datei definiert TeXnicCenter automatisch auch als Hauptdatei.
 
 \section{Aufbauen einer Verzeichnisstruktur}
 
@@ -42,7 +42,7 @@ In deiner Hauptdatei fügst du praktisch nur \texttt{\textbackslash include} und 
 Das hat verschiedene Vorteile:
 
 \begin{itemize}
-	\item Durch einfaches Austauschen der einzelnen \texttt{\textbackslash include} Befehle kannst du die Kapitel neu anordnen.
+	\item Durch einfaches Austauschen der einzelnen \texttt{\textbackslash include}"=Befehle kannst du die Kapitel neu anordnen.
 	\item Indem du z.\,B. den Befehl \texttt{\textbackslash includeonly\{kapitel/ersteskapitel\}} als ersten Befehl in Listing \ref{lst:beispiel05} einfügst, wird nur genau das Kapitel \enquote{Erstes Kapitel} erzeugt. Was natürlich sehr viel schneller geht, als wenn das ganze Dokument erstellt werden müsste. Das spart dir viel Zeit, wenn du die Darstellung eines einzelnen Kapitels optimierst.
 	\item Wenn du später ähnliche Dokumente erstellst, kannst du die separate Headerdatei kopieren und wiederverwenden.
 \end{itemize}

--- a/chapters/grundlagen.tex
+++ b/chapters/grundlagen.tex
@@ -10,10 +10,10 @@
 \label{sec:grundlagen}
 \index{Grundlagen|(}
 
-\DMLLaTeX \ ist einfacher zu erlernen, als du vielleicht denkst. Anders als grafische Tools, welche WYSIWYG\footnote{What You See Is What You Get} bieten (wollen), beschreibst du die Struktur deines Dokuments in einer speziellen Sprache. Danach \enquote{kompilierst} du das Dokument und erzeugst daraus das fertige Dokument, zum Beispiel eine PDF-Datei.
+\DMLLaTeX \ ist einfacher zu erlernen, als du vielleicht denkst. Anders als grafische Tools, welche WYSIWYG\footnote{What You See Is What You Get} bieten (wollen), beschreibst du ähnlich wie bei HTML die Struktur deines Dokuments in einer speziellen Sprache. Danach \enquote{kompilierst} du das Dokument und erzeugst dadurch das fertige Dokument, zum Beispiel eine PDF-Datei.
 
 
-\section{Das erste kleine LaTeX Dokument}
+\section{Das erste kleine LaTeX"=Dokument}
 
 \subsection{Erstellen eines neuen Projekts}
 \label{sec:erstellenneuesprojekt}
@@ -30,7 +30,7 @@ Starte jetzt im TeXnicCenter ein neues Projekt. Dazu gehst du auf \enquote{Datei
 \end{figure}
 
 
-Ein Dialogfenster öffnet sich, in dem du den Projekttyp\index{Projekttyp} auswählen kannst. Es steht nur \enquote{Leeres Projekt} zur Verfügung. Klicke dieses Icon an und wähle rechts das Basisverzeichnis aus. Für jedes \DMLLaTeX \ Dokument wird ein neues Unterverzeichnis in diesem Basisverzeichnis erstellt.
+Ein Dialogfenster öffnet sich, in dem du den Projekttyp\index{Projekttyp} auswählen kannst. Es steht nur \enquote{Leeres Projekt} zur Verfügung. Klicke dieses Icon an und wähle rechts das Basisverzeichnis aus. Für jedes \DMLLaTeX"=Dokument wird ein neues Unterverzeichnis in diesem Basisverzeichnis erstellt.
 
 Ich empfehle dir Folgendes: Lege auf deinem Datenlaufwerk (z.\,B. M:\textbackslash ) ein Verzeichnis \enquote{Dokumente} an. Darin erstellst du z.\,B. noch ein Unterverzeichnis \enquote{LaTeX}.
 
@@ -58,7 +58,7 @@ Schreibe jetzt folgende Zeilen in die leere Datei:
 \lstinputlisting[caption=Beispiel1.tex, label=lst:beispiel01, frame=tb]%
 	{listings/beispiel01.tex}
 
-Zeile 5--11 ist der Kopfbereich der Datei. Hier definieren wir Folgendes:
+Die Zeilen 5--11 sind der Kopfbereich der Datei. Hier definieren wir Folgendes:
 
 \begin{description}
 \item[Zeile 5] Der Befehl \texttt{\textbackslash documentclass}\index{documentclass@\texttt{\textbackslash documentclass}} definiert unsere Dokumentklasse\index{Dokumentklasse}. Wir verwenden hier die Klasse \enquote{scrartcl}, welche für kleinere Artikel gedacht ist. Neben der \KOMAScript{} Klasse \enquote{scrartcl} gibt es z.\,B. noch \enquote{scrbook}, \enquote{scrreprt}, \enquote{scrlettr} und andere weniger übliche.

--- a/chapters/header.tex
+++ b/chapters/header.tex
@@ -22,7 +22,7 @@
 	headsepline,%         Linie nach Kopfzeile.
 	footsepline,%         Linie vor Fusszeile.
 	bibliography=totoc,%  Literaturverzeichnis im Inhaltsverzeichnis nummeriert einfügen.
-	index=totoc,%            Index ins Inhaltsverzeichnis einfügen.
+	index=totoc,%         Index ins Inhaltsverzeichnis einfügen.
 	ngerman%              Sprache des Dokumentes
 ]{scrbook}
 % das package listings benutzt altes komascript, siehe
@@ -196,6 +196,12 @@
 \def\AmS{$\mathcal{A}$\kern-.1667em\lower.5ex\hbox
     {$\mathcal{M}$}\kern-.125em$\mathcal{S}$}
 \def\AmSmath{\AmS{}math}
+
+\newcommand{\urlindent}[2][]{%
+	\begin{addmargin}[1em]{0em}%
+		\url{#2}{#1}%
+	\end{addmargin}%
+}
 
 % D. AKTIONEN
 % ---------------------------------------------------------------------------

--- a/chapters/header.tex
+++ b/chapters/header.tex
@@ -136,13 +136,6 @@
 %
 \usepackage{lmodern}
 
-%
-% 14. Typewriter Font LuxiMono laden.
-%
-\usepackage[scaled=.85]{luximono}
-
-
-% 
 % B. EINSTELLUNGEN
 % ---------------------------------------------------------------------------
 %

--- a/chapters/header.tex
+++ b/chapters/header.tex
@@ -21,13 +21,17 @@
 	a4paper,%             Wir verwenden A4 Papier.
 	oneside,%             Einseitiger Druck.
 	12pt,%                Grosse Schrift, besser geeignet für A4.
-	halfparskip,%         Halbe Zeile Abstand zwischen Absätzen.
+	parskip=half,%        Halbe Zeile Abstand zwischen Absätzen.
 	%chapterprefix,%       Kapitel mit 'Kapitel' anschreiben.
 	headsepline,%         Linie nach Kopfzeile.
 	footsepline,%         Linie vor Fusszeile.
-	bibtotocnumbered,%    Literaturverzeichnis im Inhaltsverzeichnis nummeriert einfügen.
-	idxtotoc%             Index ins Inhaltsverzeichnis einfügen.
+	bibliography=totoc,%  Literaturverzeichnis im Inhaltsverzeichnis nummeriert einfügen.
+	index=totoc,%            Index ins Inhaltsverzeichnis einfügen.
+	ngerman%              Sprache des Dokumentes
 ]{scrbook}
+% das package listings benutzt altes komascript, siehe
+% https://tex.stackexchange.com/questions/51867/koma-warning-about-toc
+\usepackage{scrhack}
 % tabellen mit automatischem zeilenumbruch
 \usepackage{tabularx}
 

--- a/chapters/header.tex
+++ b/chapters/header.tex
@@ -34,6 +34,13 @@
 \usepackage{scrhack}
 % tabellen mit automatischem zeilenumbruch
 \usepackage{tabularx}
+% avoid overfull boxes on page numbers >99, see 
+% https://tex.stackexchange.com/questions/49887/overfull-hbox-warning-for-toc-entries-when-using-memoir-documentclass
+% http://compgroups.net/comp.text.tex/page-number-alignment-in-koma-script-table-of-c/1914765
+\makeatletter
+\renewcommand*{\@tocrmarg}{2.55em}
+\renewcommand*{\@pnumwidth}{2.2em}
+\makeatother
 
 
 %

--- a/chapters/header.tex
+++ b/chapters/header.tex
@@ -28,6 +28,8 @@
 	bibtotocnumbered,%    Literaturverzeichnis im Inhaltsverzeichnis nummeriert einfügen.
 	idxtotoc%             Index ins Inhaltsverzeichnis einfügen.
 ]{scrbook}
+% tabellen mit automatischem zeilenumbruch
+\usepackage{tabularx}
 
 
 %
@@ -47,7 +49,7 @@
 %  4. Paket für die Lokalisierung ins Deutsche laden.
 %     Wir verwenden neue deutsche Rechtschreibung mit 'ngerman'.
 %
-\usepackage[ngerman]{babel}
+\usepackage[main=ngerman,french]{babel}
 
 
 %

--- a/chapters/header.tex
+++ b/chapters/header.tex
@@ -1,4 +1,3 @@
-%
 % Diplomarbeit mit LaTeX
 % ===========================================================================
 % This is part of the book "Diplomarbeit mit LaTeX".
@@ -7,12 +6,9 @@
 % See the file main.tex for copying conditions.
 %
 
-%
 % A. DOKUMENTKLASSE
 % ---------------------------------------------------------------------------
-%
 
-%
 %  1. Definieren der Dokumentklasse.
 %     Wir verwenden die KOMA-Script Klasse 'scrbook' für ein Buch.
 %
@@ -42,8 +38,6 @@
 \renewcommand*{\@pnumwidth}{2.2em}
 \makeatother
 
-
-%
 %  2. Festlegen der Zeichencodierung des Dokuments und des Zeichensatzes.
 %     Wir verwenden 'Latin1' (ISO-8859-1) für das Dokument,
 %     und die 'T1' codierung für die Schrift.
@@ -51,37 +45,29 @@
 \usepackage[latin1]{inputenc}
 \usepackage[T1]{fontenc}
 
-%
 %  3. Packet für die Index-Erstellung laden.
 %
 \usepackage{makeidx}
 
-%
 %  4. Paket für die Lokalisierung ins Deutsche laden.
 %     Wir verwenden neue deutsche Rechtschreibung mit 'ngerman'.
 %
 \usepackage[main=ngerman,french]{babel}
 
-
-%
 %  5. Paket für Anführungszeichen laden.
 %     Wir setzen den Stil auf 'swiss', und verwenden so die Schweizer Anführungszeichen.
 %
 \usepackage[style=swiss]{csquotes}
 
-
-%
 %  6. Paket für erweiterte Tabelleneigenschaften.
 %
 \usepackage{array}
 
-%
 %  7. Paket um Grafiken im Dokument einbetten zu können.
 %     Im PDF sind GIF, PNG, und PDF Grafiken möglich.
 %
 \usepackage{graphicx}
 
-%
 %  8. Pakete für mathematischen Textsatz.
 %
 \usepackage{amsmath}
@@ -89,18 +75,15 @@
 \usepackage{dsfont}
 %\usepackage{mathtools}
 
-%
 %  9. Paket um Textteile drehen zu können.
 %
 \usepackage{rotating}
 
-%
 % 10. Paket für Farben an verschieden Stellen. 
 %     Wir definieren zusätzliche benannte Farben.
 %
 \usepackage{color}
 
-%
 % 11. Paket für spezielle PDF features.
 %
 \usepackage[%
@@ -116,14 +99,12 @@
 	pdflang=de%                                               Sprache des Dokuments.
 ]{hyperref}
 
-%
 % 12. Paket um Quellcode sauber zu formatieren.
 %     Mit der option 'savemem' verschieben wir das laden von 
 %     einzelnen Programmiersprachen auf einen späteren Zeitpunkt.
 %
 \usepackage[savemem]{listings}
 
-%
 % 13a. Privates Paket für die Schriftart 'Goudy Sans' laden.
 %      Dieses Paket ist nur für die publizierte Version des Dokuments gedacht
 %      und an dieser Stelle mit den nachfolgenden Anweisungen auskommentiert.
@@ -138,9 +119,7 @@
 
 % B. EINSTELLUNGEN
 % ---------------------------------------------------------------------------
-%
 
-%
 %  1. Definieren von eigenen benannten Farben.
 %     Für spätere Verwendung in dem Dokument, definieren wir einzelne
 %     benannte Farben.
@@ -148,18 +127,15 @@
 \definecolor{LinkColor}{rgb}{0,0,0.5}
 \definecolor{ListingBackground}{rgb}{0.85,0.85,0.85}
 
-%
 %  2. KOMA-Script Option, Zeilenumbruch bei Bildbeschreibungen.
 %
 \setcapindent{1em}
 
-%
 %  3. Stil der Kopf- und Fusszeilen.
 %     Wir aktivieren mit 'headings' laufende Seitentitel.
 %
 \pagestyle{headings}
 
-%
 %  4. Stil der Überschriften auf normale Schrift.
 %     Wir verwenden für die Überschriften den selben Font wie für den Text.
 %
@@ -181,7 +157,6 @@
 	bookmarksnumbered=true%  Überschriftsnummerierung im PDF Inhalt anzeigen.
 }
 
-%
 %  6. Einstellungen für das 'listings' Paket.
 %
 \lstloadlanguages{TeX} % TeX sprache laden, notwendig wegen option 'savemem'
@@ -201,19 +176,15 @@
 	extendedchars=true,      % Alle Zeichen vom Latin1 Zeichensatz anzeigen.
 	backgroundcolor=\color{ListingBackground}} % Hintergrundfarbe des Quellcodes setzen.
 
-%
 % C. NEUE MAKROS UND UMGEBUNGEN
 % ---------------------------------------------------------------------------
 
-
-%
 %  1. Umgebung für Änerungsliste mit einem speziellen Aufzählungszeichen.
 %
 \newenvironment{ListChanges}%
 	{\begin{list}{$\diamondsuit$}{}}%
 	{\end{list}}
 
-%
 %  2. Ersatz für die \LaTeX und \TeX Befehle für korrekte Darstellung.
 %     Wir verwenden die 'Latin Modern Family' ('lm') als Font, da diese im
 %     vergleich zu 'Computer Modern' ('cm') auch PostScript Dateien
@@ -226,24 +197,15 @@
     {$\mathcal{M}$}\kern-.125em$\mathcal{S}$}
 \def\AmSmath{\AmS{}math}
 
-%
 % D. AKTIONEN
 % ---------------------------------------------------------------------------
-%
 
-%
 %  1. Index erzeugen.
 %
 \makeindex
 
-%
 % E. SILBENTRENNUNG
 % ---------------------------------------------------------------------------
-%
 
 \hyphenation{De-zi-mal-trenn-zeichen In-stal-la-ti-ons-as-sis-tent}
 
-%
-% ===========================================================================
-% EOF
-%

--- a/chapters/installation.tex
+++ b/chapters/installation.tex
@@ -10,21 +10,27 @@
 \label{sec:installation}
 \index{Installation|(}
 
-\section{MiKTeX unter Windows}
+\section{MiKTeX}
 \index{Installation!MiKTeX|(}
 
-Für Windows existiert die \DMLLaTeX-Distribution \enquote{MiKTeX}~\cite{MiKTeX}. Diese lässt sich auf einfachste Art und Weise installieren. Die Distribution ist kostenlos und wird unter einer Open-Source-Lizenz vertrieben. Wer mag, kann sich aber auch registrieren lassen, falls er oder sie E-Mail Support wünscht.
+Mit \enquote{MiKTeX}~\cite{MiKTeX} existiert neben \enquote{Tex Live} eine weitere \DMLLaTeX"=Distribution, die mittlerweile für Windows, macOS und Linux verfügbar ist und sich einfach installieren lässt.
+MiKTeX ist freie Software, d.\,h. ist kostenlos und wird unter einer Open-Source-Lizenz vertrieben.
+
+Im Folgenden wird die Installation unter Windows beschrieben. Für andere Systeme werden Tutorials auf der MiKTeX-Website angeboten. Insbesondere für Linux bietet sich stattdessen die Installation von Tex Live an, was sich in der Regel mit einer Zeile erledigen lässt.
 
 \subsection{Herunterladen des Setup-Programms}
 
-Geh auf die Adresse \url{http://www.miktex.org/}. Dort findest du verschiedene Versionen des Installers, welche du herunterladen kannst.
+Unter 
+\urlindent{https://www.miktex.org/}
+findest du verschiedene Versionen des Installers, welche du herunterladen kannst.
 
-Empfehlenswert ist hier der \enquote{Basic MiKTeX Installer}, da er die besonders häufig verwendeten Pakete bereits enthält und diese nicht mehr nachträglich heruntergeladen werden müssen. Diese Installer-Datei ist in der Version 2.7 über 70\,MB groß, weshalb eine schnelle Internetverbindung sich hier als vorteilhaft erweist.
+Empfehlenswert ist hier der \enquote{Basic MiKTeX Installer}, da er die besonders häufig verwendeten Pakete bereits enthält, sodass diese nicht mehr nachträglich heruntergeladen werden müssen. Diese Installer-Datei ist einige Hundert MB groß.
 
 Wähle diesen Link an und lade den Installer herunter.
 
-
 \subsection{Starten des Setups}
+Der im Folgenden dargestellte Ablauf der Installation mag sich im Laufe der Zeit geringfügig ändern. Die jeweils aktuellsten Informationen befinden sich (allerdings nur auf Englisch) unter
+\urlindent[.]{https://miktex.org/howto/install-miktex}
 
 \begin{figure}[hb]
 	\begin{captionbeside}{Nach dem Start des Programms erscheint dieser Screen. Du musst die Lizenzbedingungen akzeptieren.}[l]
@@ -75,7 +81,6 @@ Wähle diesen Link an und lade den Installer herunter.
 	\label{fig:install08}
 \end{figure}
 
-
 \clearpage % Warten bis alle Floats ausgegeben sind.
 
 \subsection{Herunterladen der Pakete}
@@ -83,7 +88,7 @@ Wähle diesen Link an und lade den Installer herunter.
 
 Während der Benutzung von MiKTeX und TeXnicCenter wirst Du bei fehlenden Paketen gefragt, ob sie heruntergeladen werden sollen. Dies ist ein bequemer und minimalistischer Ansatz, da nur genau die Pakete installiert werden, die Du tatsächlich brauchst, und diese immer in der aktuellen Version aus dem Netz geladen werden. 
 
-Alternativ Du kannst natürlich alle verfügbaren Pakete auf einmal herunterladen -- z.B. sinnvoll, wenn Du nur vorübergehend in der Uni breitbandig mit dem Internet verbunden bist und Festplattenplatz keinen Engpass darstellt (die allermeisten Pakete wirst Du nie verwenden, also den davon eingenommenen Platz verschwenden). Auf diese Weise stehen immer alle Pakete zur Verfügung.
+Alternativ Du kannst alle verfügbaren Pakete auf einmal herunterladen. Das ist z.\,B. dann sinnvoll, wenn Du nur vorübergehend breitbandig mit dem Internet verbunden bist und Festplattenplatz keinen Engpass darstellt (die allermeisten Pakete wirst Du nie verwenden, also den davon eingenommenen Platz verschwenden). Auf diese Weise stehen immer alle Pakete zur Verfügung.
 
 Wie du manuell einige oder alle Pakete installieren kannst, ist in den Abbildungen \ref{fig:install10} bis \ref{fig:install05b} beschrieben. 
 
@@ -115,11 +120,15 @@ Wie du manuell einige oder alle Pakete installieren kannst, ist in den Abbildung
 \section{Der Editor TeXnicCenter}
 \index{Installation!TeXnicCenter|(}
 
-Um \DMLLaTeX \ Dokumente einfach editieren zu können, bietet sich der Editor \enquote{TeXnicCenter}~\cite{TeXnicCenter} an. Dieser unterstützt einfache Navigation in der Dokumentstruktur, Projektverwaltung und einfachen Aufruf von \DMLLaTeX.
+Um \DMLLaTeX"=Dokumente einfach editieren zu können, bietet sich unter Windows der freie Editor \enquote{TeXnicCenter}~\cite{TeXnicCenter} an. Dieser unterstützt einfache Navigation in der Dokumentstruktur, Projektverwaltung und einfachen Aufruf von \DMLLaTeX.
+
+Alternativen dazu sind die TeX-Editoren \enquote{Kile} und \enquote{Texmaker}, die auch für Linux erhältlich sind; letzterer auch für macOS.
 
 \subsection{Herunterladen von TeXnicCenter}
 
-Auf der Webseite des TeXnicCenter Autors~\cite{TeXnicCenter} wählst du in der Navigation links \enquote{Download} an, und in der folgenden Liste, unter dem Punkt \enquote{End-User Downloads} z.\,B. \enquote{TeXnicCenter Setup, Version 1 Beta 7.01} aus. Vielleicht ist mittlerweile bereits eine neuere Version erschienen. Wichtig ist, dass du die \enquote{Binaries} in Form einer Setup \enquote{.exe} Datei herunterlädst.
+Auf der TeXnicCenter"=Webseite
+\urlindent{https://www.texniccenter.org/}
+wählst du in der Navigation \enquote{Download} an und in der folgenden Liste \enquote{TeXnicCenter 2.02 Stable (64 Bit)} aus. Die 32-Bit-Variante ist nur für sehr alte Computer gedacht. Möglicherweise ist mittlerweile auch eine neuere Version erschienen.
 
 \subsection{Starten des Setups}
 
@@ -140,7 +149,7 @@ Starte das heruntergeladene Setup. Die Installation ist in den Abbildungen \ref{
 \end{figure}
 
 \begin{figure}[hb]
-	\begin{captionbeside}[Wahl des Installationsverzeichnisses]{Hier wählst du das Verzeichnis aus, in das der Editor installiert werden soll. Am Besten übernimmst du die Vorgabe.}[l]
+	\begin{captionbeside}[Wahl des Installationsverzeichnisses]{Hier wählst du das Verzeichnis aus, in das der Editor installiert werden soll. Am besten übernimmst du die Vorgabe.}[l]
 		\includegraphics[width=7cm]{images/TeXnicCenter-install-03.png}
 	\end{captionbeside}
 	\label{fig:install22}
@@ -186,17 +195,11 @@ Starte das heruntergeladene Setup. Die Installation ist in den Abbildungen \ref{
 \clearpage % Warten bis alle Floats ausgegeben sind.
 
 
-\section{Adobe Reader}
+\section{PDF-Viewer}
 \index{Installation!Adobe Reader}
 
-Jetzt solltest du noch die neuste Version des \enquote{Adobe Reader} herunterladen. Du benötigst mindestens die Version 5.0 (damals noch \enquote{Acrobat Reader}). Das Programm ist kostenlos und du solltest es nicht mit dem teuren \enquote{Adobe Acrobat} verwechseln, dem Programm, welches PDF-Dateien \emph{erzeugt}. Wir werden mit \DMLLaTeX \ unsere PDFs erzeugen.
+Zur Betrachtung der von uns mittels \DMLLaTeX{} erzeugten PDF-Dateien eignen sich alle gängigen PDF-Viewer. Unter Windows ist der proprietäre \enquote{Adobe Acrobat Reader} vermutlich der verbreitetste. Daneben gibt es freie Betrachter wie \enquote{Evince} oder \enquote{Okular}, die unter allen drei großen Betriebssystemen laufen. 
 
-Dazu gehst du auf die Webseite von Adobe~\cite{Adobe} und suchst nach einem Link \enquote{Download Adobe Reader} oder ähnlichem. Vielleicht findest du auch ein anklickbares \enquote{Get Adobe Reader} Icon. 
-
-Du gelangst auf eine Seite mit einigen weiteren Informationen zum Adobe Reader. Weiter unten findest du drei Schritte zum Download.
-
-Bei den Feldern im ersten Schritt wählst du Deutsch und dein Betriebssystem aus. Die Felder im zweiten Schritt kannst du leer lassen (empfohlen).
-
-Nach dem Klick auf \enquote{Download} startet nach einigen Sekunden der Download von einem kleinen \enquote{Downloadmanager}. Nach dem Start von diesem Programm wird der Adobe Reader heruntergeladen und auf deinem System installiert.
+Mittlerweile können auch Webbrowser wie Firefox oder Chrome bzw. Chromium PDF-Dateien anzeigen, weshalb auf eine Installationsanleitung in dieser Stelle verzichtet wird.
 
 \index{Installation|)}

--- a/chapters/installation.tex
+++ b/chapters/installation.tex
@@ -102,7 +102,7 @@ Wie du manuell einige oder alle Pakete installieren kannst, ist in den Abbildung
 \end{figure}
 
 \begin{figure}
-	\begin{captionbeside}[Download]{Die Pakete werden aus dem Netz geladen und Dir Statusinformationen angezeigt. Klicke danach auf Close. Damit ist die Paketinstallation beendet.}[l]
+	\begin{captionbeside}[Download]{Während die Pakete aus dem Netz geladen werden, werden Dir Statusinformationen angezeigt. Klicke danach auf Close. Damit ist die Paketinstallation beendet.}[l]
 		\includegraphics[width=7cm]{images/MiKTeX-packet-install-03.png}
 	\end{captionbeside}
 	\label{fig:install05b}
@@ -133,7 +133,7 @@ Starte das heruntergeladene Setup. Die Installation ist in den Abbildungen \ref{
 \end{figure}
 
 \begin{figure}[hb]
-	\begin{captionbeside}[Anzeige der GPL]{Die GNU Public License~\cite{GPL} muß akzeptiert werden.}[l]
+	\begin{captionbeside}[Anzeige der GPL]{Die GNU General Public License~\cite{GPL} muss akzeptiert werden.}[l]
 		\includegraphics[width=7cm]{images/TeXnicCenter-install-02.png}
 	\end{captionbeside}
 	\label{fig:install21}
@@ -154,7 +154,7 @@ Starte das heruntergeladene Setup. Die Installation ist in den Abbildungen \ref{
 \end{figure}
 
 \begin{figure}[hb]
-	\begin{captionbeside}[Wahl des Namens im Startmenü]{Auch bei der Frage nach dem Namen des Eintrags ins Startmenü kannst du die Voreinstellung übernehmen.}[l]
+	\begin{captionbeside}[Wahl des Namens im Startmenü]{Auch bei der Frage nach dem Namen des Startmenüeintrags kannst du die Voreinstellung übernehmen.}[l]
 		\includegraphics[width=7cm]{images/TeXnicCenter-install-05.png}
 	\end{captionbeside}
 	\label{fig:install24}
@@ -175,7 +175,7 @@ Starte das heruntergeladene Setup. Die Installation ist in den Abbildungen \ref{
 \end{figure}
 
 \begin{figure}[thb]
-	\begin{captionbeside}[TeXnicCenter ist installiert]{TeXnicCenter ist installiert.}[l]
+	\begin{captionbeside}[TeXnicCenter ist installiert]{Schließlich wurde TeXnicCenter erfolgreich installiert.}[l]
 		\includegraphics[width=7cm]{images/TeXnicCenter-install-08.png}
 	\end{captionbeside}
 	\label{fig:install27}

--- a/chapters/konfiguration.tex
+++ b/chapters/konfiguration.tex
@@ -14,7 +14,7 @@
 
 Die \DMLLaTeX-Distribution \enquote{MiKTeX} musst du nicht konfigurieren. Es handelt sich dabei außer bei dem DVI-Betrachter um Kommandozeilentools. Du solltest nur den Editor TeXnicCenter einrichten (siehe dazu \ref{sec:KonfigurationTeXnicCenter}).
 
-Du solltest jedoch mit dem \enquote{MiKTeX Update Wizard} alle Pakete der Distribution auf den neuesten Stand zu bringen. Wie du das machst beschreibt die Hilfe zu MiKTeX ausführlich\footnote{\enquote{User Guide}$\Rightarrow$\enquote{Maintenance}$\Rightarrow$\enquote{Installing Updates}}.
+Du solltest jedoch mit dem \enquote{MiKTeX Update Wizard} alle Pakete der Distribution auf den neuesten Stand bringen. Wie du das machst, beschreibt die Hilfe zu MiKTeX ausführlich.\footnote{\enquote{User Guide}$\Rightarrow$\enquote{Maintenance}$\Rightarrow$\enquote{Installing Updates}}
 
 \section{TeXnicCenter}
 \label{sec:KonfigurationTeXnicCenter}
@@ -46,7 +46,7 @@ Nach dem ersten Start erscheint der Einrichtungsassistent. Falls du diesen berei
 \end{figure}
 
 \begin{figure}[ht]
-	\begin{captionbeside}[Anzeige der drei generierten Profile]{Der TeXnicCenter-Assistent teilt dir mit, das er drei Profile generieren wird. Ein DVI-, ein PostScript- und ein PDF-Profil. Wir werden nur das PDF-Profil verwenden.}[l]
+	\begin{captionbeside}[Anzeige der drei generierten Profile]{Der TeXnicCenter-Assistent teilt dir mit, dass er drei Profile generieren wird. Ein DVI-, ein PostScript- und ein PDF-Profil. Wir werden nur das PDF-Profil verwenden.}[l]
 		\includegraphics[width=7cm]{images/konfiguration04.png}
 	\end{captionbeside}
 	\label{fig:konfiguration04}
@@ -57,9 +57,7 @@ Nach dem ersten Start erscheint der Einrichtungsassistent. Falls du diesen berei
 \subsection{Die Rechtschreibprüfung}
 \index{Rechtschreibprufung@Rechtschreibprüfung}
 
-Ein sehr schönes und nützliches Feature, welches dir TeXnicCenter bietet ist die Rechtschreibprüfung. Wähle dazu im Menü \emph{Extras} den Punkt \emph{Optionen} aus. In dem Dialog, der sich geöffnet hat wählst du den Reiter \emph{Rechtschreibung} aus. Dort kannst du die verschiedenen Optionen der Rechtschreibprüfung einstellen.
-
-Die möglichen Einstellparameter sind selbsterklärend, was du sehr gut in Abbildung \ref{fig:rechtschreibung} siehst.
+Ein sehr nützliches Feature, welches dir TeXnicCenter bietet, ist die Rechtschreibprüfung. Wähle dazu im Menü \emph{Extras} den Punkt \emph{Optionen} aus. In dem Dialog, der sich öffnet, wählst du den Reiter \emph{Rechtschreibung} aus. Dort kannst du die verschiedenen Optionen der Rechtschreibprüfung einstellen, wie du in Abbildung \ref{fig:rechtschreibung} siehst.
 
 \begin{figure}
 	\centering
@@ -68,13 +66,8 @@ Die möglichen Einstellparameter sind selbsterklärend, was du sehr gut in Abbildu
 	\label{fig:rechtschreibung}
 \end{figure}
 
-Falls eine gewünschte Sprache fehlt, kannst du zusätzliche Wörterbücher installieren. Wörterbücher diverser Sprachen, auch der neuen und alten deutschen Rechtschreibung, findest du unter folgender Internetadresse zum kostenlosen Download:
+Falls eine gewünschte Sprache fehlt, findest du Wörterbücher weiterer Sprachen unter
+\urlindent{https://extensions.services.openoffice.org/dictionaries}
+zum kostenlosen Download. Entpacke die in der heruntergeladenen ZIP"=Datei enthaltenen Dateien in das Unterverzeichnis \enquote{Language} deiner TeXnicCenter"=Installation, normalerweise ist das:
 
-\url{http://lingucomponent.openoffice.org/download\_dictionary.html}
-
-Entpacke die in der heruntergeladenen ZIP Datei enthaltenen Dateien in das Unterverzeichnis \enquote{Language} deiner TeXnicCenter Installation. Die TeXnicCenter Installation findest du normalerweise in dem folgenden Verzeichnis:
-
-\verb|C:\Programme\TeXnicCenter\Language|
-
-
-
+\verb|C:\Programme\TeXnicCenter\Language|.

--- a/chapters/konfiguration.tex
+++ b/chapters/konfiguration.tex
@@ -22,17 +22,17 @@ Du solltest jedoch mit dem \enquote{MiKTeX Update Wizard} alle Pakete der Distri
 
 \subsection{TeXnicCenter für die Verwendung mit MiKTeX konfigurieren}
 
-Nach dem ersten Start erscheint der Einrichtungsassistent. Falls du diesen bereits abgebrochen hast, kann man Ihn über das Menü \enquote{Ausgabe}, \enquote{Ausgabeprofile definieren...} und dort in dem Dialog \enquote{Assistent} links unten erneut aufrufen. Doch wie schon gesagt, der Assistent startet normalerweise beim ersten Start vom TeXnicCenter automatisch.
+Nach dem ersten Start erscheint der Einrichtungsassistent. Falls du diesen bereits abgebrochen hast, kann man ihn über das Menü \enquote{Ausgabe}, \enquote{Ausgabeprofile definieren...} und dort in dem Dialog \enquote{Assistent} links unten erneut aufrufen. Doch wie schon gesagt, der Assistent startet normalerweise beim ersten Start vom TeXnicCenter automatisch.
 
 \begin{figure}[hb]
-	\begin{captionbeside}[Start des Konfigurations-Assistenten]{Der Assistent Startet mit dem diesem Screen}[l]
+	\begin{captionbeside}[Start des Konfigurations-Assistenten]{Der Konfigurationsassistent  startet mit diesem Screen.}[l]
 		\includegraphics[width=7cm]{images/konfiguration01.png}
 	\end{captionbeside}
 	\label{fig:konfiguration01}
 \end{figure}
 
 \begin{figure}[hb]
-	\begin{captionbeside}[Frage, für welche Distribution TeXnicCenter eingerichtet werden soll]{Hier teilt dir der Installationsassistent mit, dass er die installierte \enquote{MiKTeX}-Distribution erkannt hat und fragt, ob er den Editor mit dieser \DMLLaTeX-Distribution konfigurieren soll. Du wählst natürlich \enquote{Ja}.}[l]
+	\begin{captionbeside}[Frage, für welche Distribution TeXnicCenter eingerichtet werden soll]{Hier teilt der Installations"=Assistent mit, dass die installierte MiKTeX"=Distribution erkannt wurde und fragt, ob er den Editor mit dieser \DMLLaTeX"=Distribution konfigurieren soll. Du wählst natürlich \enquote{Ja}.}[l]
 		\includegraphics[width=7cm]{images/konfiguration02.png}
 	\end{captionbeside}
 	\label{fig:konfiguration02}

--- a/chapters/listings.tex
+++ b/chapters/listings.tex
@@ -72,14 +72,14 @@
 \subsection{Erstes Kapitel der Diplomarbeit}
 %\label{subsec:erstes_kapitel}
 
-\lstinputlisting[caption=Erstes Kapitel der Diplomarbeit - ohne Glossareinträge, label=lst:erstes_kapitel,
+\lstinputlisting[caption=Erstes Kapitel der Diplomarbeit -- ohne Glossareinträge, label=lst:erstes_kapitel,
  frame=tb]
 	{template_diplomarbeit/kapitel/charakteristik_spuerhund.tex}
 
 \subsection{Zweites Kapitel der Diplomarbeit}
 \label{subsec:zweites_kapitel}
 
-\lstinputlisting[caption=Zweites Kapitel der Diplomarbeit - mit Glossareinträge, label=lst:zweites_kapitel,
+\lstinputlisting[caption=Zweites Kapitel der Diplomarbeit -- mit Glossareinträge, label=lst:zweites_kapitel,
  frame=tb]
 	{template_diplomarbeit/kapitel/zukunftsaussichten_spuerhund.tex}
 

--- a/chapters/listings.tex
+++ b/chapters/listings.tex
@@ -90,7 +90,6 @@
  frame=tb]
 	{template_diplomarbeit/kapitel/eidesstattliche_erklaerung.tex}
 
-
 \newpage
 \subsection{Batchdatei zum Übersetzen des LaTeX-Dokumentes}
 \label{subsec:batchdatei}

--- a/chapters/listings.tex
+++ b/chapters/listings.tex
@@ -60,8 +60,6 @@
 \lstinputlisting[caption=Einleitung der Diplomarbeit, label=lst:einleitung, frame=tb]
 	{template_diplomarbeit/kapitel/abstract.tex}
 
-
-\newpage	
 \subsection{Danksagung zur Diplomarbeit}
 %\label{subsec:danksagung}
 
@@ -85,10 +83,10 @@
  frame=tb]
 	{template_diplomarbeit/kapitel/zukunftsaussichten_spuerhund.tex}
 
+\newpage
 \subsection{Eidesstattliche Erklärung zur Diplomarbeit}
-%\label{subsec:zweites_kapitel}
-
-\lstinputlisting[caption=Eidesstattliche Erklärung der Diplomarbeit - ist abhängig von den Bedingungen der Uni bzw. FH/TH anzupassen, label=lst:eidesstattliche_erklaerung,
+\label{subsec:eidesstatt}
+\lstinputlisting[caption=Eidesstattliche Erklärung -- an Hochschul-Bedingungen anzupassen, label=lst:eidesstattliche_erklaerung,
  frame=tb]
 	{template_diplomarbeit/kapitel/eidesstattliche_erklaerung.tex}
 

--- a/chapters/literaturverzeichnis.tex
+++ b/chapters/literaturverzeichnis.tex
@@ -157,7 +157,7 @@ Einen Überblick über die wichtigsten Attributfelder gibt folgende Tabelle:
 			month &Monat der Veröffentlichung\\
 			\hline
 			pages &Eine oder mehrere Seitenzahlen oder -bereiche,\\
-						&z.B. 42 -- 50 oder 12, 43, 67.\\
+						&z.\,B. 42--50 oder 12, 43, 67.\\
 			\hline
 			publisher &Name des Verlegers.\\
 			\hline

--- a/chapters/literaturverzeichnis.tex
+++ b/chapters/literaturverzeichnis.tex
@@ -148,7 +148,7 @@ Einen Überblick über die wichtigsten Attributfelder gibt folgende Tabelle:
 			\hline
 			chapter &Eine Kapitelnummer oder Kapitelbezeichnung.\\
 			\hline
-			edition &Auflage des Buches, kann eine Zahl oder eine ausgeschriebene Zahl sein.\\
+			edition &Auf\/lage des Buches: Zahl oder ausgeschriebene Zahl.\\
 			\hline
 			institution &Institution, an der das Werk entstand.\\
 			\hline

--- a/chapters/nuetzlichepakete.tex
+++ b/chapters/nuetzlichepakete.tex
@@ -59,5 +59,3 @@ Immer, wenn du jetzt ein einfaches Anführungszeichen (\texttt{''}) eingibst, wir
 
 Das \enquote{csquotes}-Paket bietet noch eine Fülle an Möglichkeiten, wie zum Beispiel verschiedene Sprachen, Blockquotes und vieles mehr. Die komplette Dokumentation findest du in dem Installationsverzeichniss von MiKTeX unter dem Pfad \enquote{doc\textbackslash latex\textbackslash csquotes}.
 
-
-

--- a/chapters/tabellenundbilder.tex
+++ b/chapters/tabellenundbilder.tex
@@ -154,7 +154,7 @@ Das Beispiel siehst du als Tabelle \ref{tbl:beispieltabelle3} auf Seite \pageref
 \subsection{Tabellenbreite bestimmen bzw. automatischer Zeilenumbruch}
 \index{Tabellen!Spaltenbeite bestimmen}\index{Tabellen!Automatischer Zeilenumbruch}
 
-Normalerweise werden lange Zeilen nicht automatisch umbrochen, sondern \DMLLaTeX \ schreibt froh und munter über den Seitenrand hinaus. Man kann manuelle Zeilenumbrüche mit \textbackslash \textbackslash ~ einfügen, was hart an Masochismus grenzt, wenn man mehr als eine Hand voll Tabellen hat und das Layout (Ränder, Schriftgröße,...) geändert wird -- was bei größeren Arbeiten durchaus vorkommt, z.B. mal mit und mal ohne Korrekturrand, je nach Bindungsart unterschiedlicher Abstand usw.
+In konventionellen Tabellen werden lange Zeilen nicht automatisch umbrochen, sondern \DMLLaTeX \ schreibt froh und munter über den Seitenrand hinaus. Man kann manuelle Zeilenumbrüche mit \textbackslash \textbackslash \ einfügen, was hart an Masochismus grenzt, wenn man mehr als eine Hand voll Tabellen hat und das Layout (Ränder, Schriftgröße, \ldots) geändert wird -- was bei größeren Arbeiten durchaus vorkommt, z.\,B. mal mit und mal ohne Korrekturrand, je nach Bindungsart unterschiedlicher Abstand usw.
 
 \begin{table}[h]	
 		\begin{tabular}{| l | l |}  
@@ -184,10 +184,10 @@ Normalerweise werden lange Zeilen nicht automatisch umbrochen, sondern \DMLLaTeX
 	\label{tab:Tabelle_zu_breit_manuell}
 \end{table}
 
-Um die Zeilenumbrüche automatisiert setzen zu lassen, muß man die Breite der Spalte(n) mit \enquote{zu viel} Text festlegen. Dabei können entweder absolute Werte verwendet werden, z.B. 5cm oder 10em, oder sog. \textit{command lengths}, sozusagen Variablen, deren Wert von der Dokumentenklasse und Präambel abhängen, z.B. \textbackslash textwidth (Spaltenbreite in aktueller Umgebung). Ersteres ist exakter, aber man muß bei jeder Layoutänderung \textit{alle} Tabellen überprüfen und ggf. alle Spaltenbreiten anpassen. Lästig. Letzteres ist grundsätzlich angenehmer, kann aber im Einzelfall Probleme verursachen, z.B. wenn eine Spalte zu schmal für ein nicht trennbares Wort wird. Also Tabellen im Ausgabeformat genau anschauen. Nebenbei: Man kann in \DMLLaTeX \ rechnen, was wir Anschauungsbeispiel machen, indem wir \textbackslash textwidth mit 0.25 bzw. 0.75 multiplizieren.
+Um die Zeilenumbrüche automatisiert setzen zu lassen, muß man die Breite der Spalte(n) mit \enquote{zu viel} Text festlegen. Dabei können entweder absolute Werte verwendet werden, z.\,B. 5\,cm oder 10\,em, oder sog. \textit{command lengths}, sozusagen Variablen, deren Wert von der Dokumentenklasse und Präambel abhängen, z.\,B. \textbackslash textwidth (Spaltenbreite in aktueller Umgebung). Ersteres ist exakter, aber man muß bei jeder Layoutänderung \textit{alle} Tabellen überprüfen und ggf. alle Spaltenbreiten anpassen. Lästig. Letzteres ist grundsätzlich angenehmer, kann aber im Einzelfall Probleme verursachen, z.\,B. wenn eine Spalte zu schmal für ein nicht trennbares Wort wird. Also Tabellen im Ausgabeformat genau anschauen. Nebenbei: Man kann in \DMLLaTeX \ rechnen, was wir Anschauungsbeispiel machen, indem wir \textbackslash textwidth mit 0.2 bzw. 0.74 multiplizieren.
 
 \begin{table}[h]		
-		\begin{tabular}{|p{0.25\textwidth} | p{0.75\textwidth} |}  
+		\begin{tabular}{|p{0.2\textwidth} | p{0.74\textwidth} |}  
 		  % automatisch an normale Textbreite angepaßt
 			\hline
 			Kurze				& Lange Spalteninhalte automatisch umbrochen\\

--- a/chapters/tabellenundbilder.tex
+++ b/chapters/tabellenundbilder.tex
@@ -12,7 +12,7 @@
 \section{Tabellen}
 \index{Tabellen}
 
-Tabellen sind in \DMLLaTeX \ ein Thema für sich. Ich beschreibe hier daher nur die sogenannte \enquote{tabular}\index{begin@\texttt{\textbackslash begin}!tabular} Umgebung. Um die tabular Umgebung nutzen zu können, solltest du zudem im Kopfbereich deines Dokuments das Paket \enquote{array}\index{Paket!array} einbinden. Das machst du mit dem Befehl:
+Tabellen sind in \DMLLaTeX \ ein Thema für sich. Ich beschreibe hier daher vor allem die sogenannte \enquote{tabular}\index{begin@\texttt{\textbackslash begin}!tabular}"=Umgebung. Um die tabular"=Umgebung nutzen zu können, solltest du zudem im Kopfbereich deines Dokuments das Paket \enquote{array}\index{Paket!array} einbinden. Das machst du mit dem Befehl:
 
 \begin{lstlisting}
 \usepackage{array}
@@ -165,7 +165,7 @@ In konventionellen Tabellen werden lange Zeilen nicht automatisch umbrochen, son
 			Links kurz	&Und rechts absichtlich viel, viel zu langer Test-Text1, Test-Text2, Test-Text3, Test-Text4, Test-Text5, Test-Text6\\
 			\hline			
 		\end{tabular}
-	\caption{Anschauungsbeispiel einer zu breit geratene Tabellenspalte}
+	\caption{Anschauungsbeispiel einer zu breit geratenen Tabellenspalte}
 	\label{tab:Tabelle_zu_breit}
 \end{table}
 
@@ -184,11 +184,11 @@ In konventionellen Tabellen werden lange Zeilen nicht automatisch umbrochen, son
 	\label{tab:Tabelle_zu_breit_manuell}
 \end{table}
 
-Um die Zeilenumbrüche automatisiert setzen zu lassen, muß man die Breite der Spalte(n) mit \enquote{zu viel} Text festlegen. Dabei können entweder absolute Werte verwendet werden, z.\,B. 5\,cm oder 10\,em, oder sog. \textit{command lengths}, sozusagen Variablen, deren Wert von der Dokumentenklasse und Präambel abhängen, z.\,B. \textbackslash textwidth (Spaltenbreite in aktueller Umgebung). Ersteres ist exakter, aber man muß bei jeder Layoutänderung \textit{alle} Tabellen überprüfen und ggf. alle Spaltenbreiten anpassen. Lästig. Letzteres ist grundsätzlich angenehmer, kann aber im Einzelfall Probleme verursachen, z.\,B. wenn eine Spalte zu schmal für ein nicht trennbares Wort wird. Also Tabellen im Ausgabeformat genau anschauen. Nebenbei: Man kann in \DMLLaTeX \ rechnen, was wir Anschauungsbeispiel machen, indem wir \textbackslash textwidth mit 0.2 bzw. 0.74 multiplizieren.
+Um die Zeilenumbrüche automatisiert setzen zu lassen, muss man die Breite der Spalte(n) mit \enquote{zu viel} Text vorab festlegen. Dabei können entweder absolute Werte verwendet werden, z.\,B. 5\,cm oder 10\,em, oder sog. \textit{command lengths}, sozusagen Variablen, deren Wert von der Dokumentenklasse und Präambel abhängen, z.\,B. \textbackslash textwidth (Spaltenbreite in aktueller Umgebung). Ersteres ist exakter, aber man muss bei jeder Layoutänderung \textit{alle} Tabellen überprüfen und ggf. alle Spaltenbreiten anpassen. Lästig. Letzteres ist grundsätzlich angenehmer, kann aber im Einzelfall Probleme verursachen, z.\,B. wenn eine Spalte zu schmal für ein nicht trennbares Wort wird. Also Tabellen im Ausgabeformat genau anschauen. Nebenbei: Man kann in \DMLLaTeX \ rechnen, was wir im folgenden Anschauungsbeispiel machen, indem wir \textbackslash textwidth mit 0.2 bzw. 0.74 multiplizieren.
 
 \begin{table}[h]		
 		\begin{tabular}{|p{0.2\textwidth} | p{0.74\textwidth} |}  
-		  % automatisch an normale Textbreite angepaßt
+		  % automatisch an normale Textbreite angepasst
 			\hline
 			Kurze				& Lange Spalteninhalte automatisch umbrochen\\
 			\hline
@@ -203,18 +203,20 @@ Hier siehst Du den Code der drei Arten von Tabellendefinitionen:
 
 \begin{lstlisting}
 \begin{table}[h]	
-	\begin{tabular}{| l | l |} 
-	  % man muß alle Umbrüche manuell machen
+	% alle Umbrüche manuell machen
+	\begin{tabular}{| l | l |}
+
+	% automatisch an normale Textbreite angepasst
 	%\begin{tabular}{|p{0.25\textwidth} | p{0.75\textwidth} |} 
-	  % automatisch an normale Textbreite angepaßt
+
+	% ggf. alle Spaltenbreiten manuell anpassen	  
 	%\begin{tabular}{|p{3cm} | p{6cm}|} 
-	  % man muß ggf. alle Spaltenbreiten manuell anpassen	  
-			\hline
-			Kurze				& Lange Spalteninhalte\\
-			\hline
-			Links kurz	&Und rechts absichtlich viel, viel zu langer Test-Text1, Test-Text2, Test-Text3, Test-Text4, Test-Text5, Test-Text6\\
-			\hline			
-		\end{tabular}
+		\hline
+		Kurze				& Lange Spalteninhalte\\
+		\hline
+		Links kurz	& Und rechts absichtlich viel, viel zu langer Test-Text1, Test-Text2, Test-Text3, Test-Text4, Test-Text5, Test-Text6\\
+		\hline			
+	\end{tabular}
 	\caption{Absichtlich zu breit geratene Tabellenspalte}
 	\label{tab:Tabelle_zu_breit}
 \end{table}
@@ -222,16 +224,39 @@ Hier siehst Du den Code der drei Arten von Tabellendefinitionen:
 
 Weitere \textit{command lengths} wie \textbackslash textwidth findest Du im Kochbuch \cite{Kochbuch}, Kapitel 8, Abschnitt Längen.
 
+	Als weit verbreitete Alternative zu \enquote{tabular}"=Umgebung soll an dieser Stelle das Package \enquote{tabularx} erwähnt werden, das es einem ermöglicht, Spalten als umbrechbar zu kennzeichnen, ohne deren exakte Breite festlegen zu müssen. Man legt dabei mit dem ersten Parameter lediglich die Gesamtbreite der Tabelle fest. Der zweite Parameter kann benutzt werden wie der erste (und einzige) Parameter der tabular"=Umgebung. Neben \texttt{l}, \texttt{c} usw. gibt es jetzt noch die Option \texttt{X}, die bedeutet, dass jene Spalte als Block gesetzt werden soll.
+\begin{table}[ht]
+	\begin{tabularx}{\textwidth}{|l|X|}
+		\hline
+		Kurze				& Lange Spalteninhalte automatisch umbrochen\\
+		\hline
+		Links kurz	& Und rechts absichtlich viel, viel zu langer Test-Text1, Test-Text2, Test-Text3, Test-Text4, Test-Text5, Test-Text6\\
+		\hline
+		\end{tabularx}
+	\caption{Mit tabularx gesetzte Tabelle}
+	\label{tab:tabularx}
+\end{table}
+
+\begin{lstlisting}
+\begin{table}[ht]	
+	\begin{tabularx}{\textwidth}{|l|X|}
+		\hline
+		Kurze				& Lange Spalteninhalte\\
+		\hline
+		Links kurz	& Und rechts absichtlich viel, viel zu langer Test-Text1, Test-Text2, Test-Text3, Test-Text4, Test-Text5, Test-Text6\\
+		\hline			
+	\end{tabularx}
+	\caption{Mit tabularx gesetzte Tabelle}
+	\label{tab:tabularx}
+\end{table}
+\end{lstlisting}
+
 \section{Bilder}
 \index{Bilder \see{Grafiken}}\index{Abbildungen \see{Grafiken}}\index{Grafiken}
 
 In dein Dokument kannst du beliebige Bilder einbetten. Dabei kannst du alle Bildformate\index{Grafiken!Format} verwenden, welche in einer PDF-Datei zulässig sind. Dies sind die Formate GIF, PNG und JPEG.
 
 Wenn du jedoch ein DVI- oder eine PostScript-Datei erzeugen möchtest, dann sind nur PostScript- oder Embedded-PostScript-Dateien zulässig.
-
-Das GIF-Format solltest du nicht verwenden, da dies rechtliche Konsequenzen mit sich bringt. Lies dazu den Kommentar unter~\cite{NoGIF}.
-%TODO: Das entsprechende Patent ist 2004 ausgelaufen. Meines Wissens kann gif nun bedenkenlos
-%verwendet werden.
 
 Um Grafiken in dein Dokument einzubetten, solltest du das Paket \enquote{graphicx}\index{Paket!graphicx} im Kopfbereich deines Dokuments einbinden. Dies machst du mit folgendem Befehl:
 
@@ -266,7 +291,7 @@ Dies fügt eine Grafik genau an der Stelle in einem Text ein, an der der Befehl h
 \subsection{Skalieren von Grafiken}
 \index{Grafik!skalieren}
 
-Der Befehl \texttt{\textbackslash includegraphics} kennt noch mehr Parameter als den Dateinamen des einzubettenden Bildes: Einer der häufig gebrauchten ist der \enquote{width} Parameter. Dieser skaliert die Grafik auf die angegebene Breite. Im folgenden Beispiel wird die Grafik auf 5cm Breite skaliert:
+Der Befehl \texttt{\textbackslash includegraphics} kennt noch mehr Parameter als den Dateinamen des einzubettenden Bildes: Einer der häufig gebrauchten ist der \enquote{width} Parameter. Dieser skaliert die Grafik auf die angegebene Breite. Im folgenden Beispiel wird die Grafik auf 5\,cm Breite skaliert:
 
 \begin{lstlisting}
 \includegraphics[width=5cm]{images/apfel.png}

--- a/chapters/tabellenundbilder.tex
+++ b/chapters/tabellenundbilder.tex
@@ -199,7 +199,7 @@ Um die Zeilenumbrüche automatisiert setzen zu lassen, muß man die Breite der Spa
 	\label{tab:Tabelle_zu_breit_automatisch}
 \end{table}
 
-Hier siehst Du den code der drei Arten von Tabellendefinitionen:
+Hier siehst Du den Code der drei Arten von Tabellendefinitionen:
 
 \begin{lstlisting}
 \begin{table}[h]	

--- a/chapters/tasten.tex
+++ b/chapters/tasten.tex
@@ -10,7 +10,7 @@
 
 Hier noch die wichtigsten Tastenkombinationen für eine schnelle Bedienung vom TeXnicCenter. Die Tastenkommandos lassen sich natürlich anpassen. Über das Hilfemenü \enquote{?} $\Rightarrow$ \enquote{Tastaturbelegung...} lässt sich die Tastaturbelegung auch anzeigen oder ausdrucken. 
 
-\begin{table}[H]
+\begin{table}
 	\begin{center}
 	\begin{tabular}{rl}
 		\textbf{Tastenkombination} & \textbf{Beschreibung} \\ \hline

--- a/chapters/textformatieren.tex
+++ b/chapters/textformatieren.tex
@@ -9,11 +9,11 @@
 \chapter{Text formatieren}
 \index{Formatieren|(}
 
-\DMLLaTeX \ kennt verschiedenste Arten, auf die ein Text formatiert und strukturiert werden kann. Ich zähle hier nur die Wichtigsten mit kleinen Beispielen auf.
+\DMLLaTeX \ kennt verschiedenste Arten, auf die ein Text formatiert und strukturiert werden kann. Ich zähle hier nur die wichtigsten mit kleinen Beispielen auf.
 
 \section{Absätze und Zeilenumbrüche}
 
-Es spielt keine Rolle, wie genau du den Text innerhalb deines Dokuments formatierst. Die folgenden beiden Listings ergeben also das selbe Resultat:
+Es spielt keine Rolle, wie genau du den Text innerhalb deines Dokuments formatierst. Die folgenden beiden Listings ergeben also dasselbe Resultat:
 
 \begin{lstlisting}
 Ein Beispieltext auf einer einzelnen Zeile.
@@ -56,13 +56,13 @@ Das ist der zweite.
 
 Voreingestellt ist \enquote{parindent}. Alle Optionen, welche mit \enquote{parskip} beginnen, erzeugen eine ganze Zeile Abstand zwischen zwei Absätzen. Die Optionen, welche mit \enquote{halfparskip} beginnen, erzeugen eine halbe Zeile Zwischenraum. Der Stern, das Plus und Minus steuern u.a., wieviel Leerraum in der letzten Zeile eines Absatzes freibleiben soll.
 
-Wie du diese Optionen bei der Dokumentklasse setzt, findest du in Kapitel \ref{sec:globaleoptionen}. Weitere Informationen zu diesen Optionen findest du in der \enquote{scrguide}, welche du hier~\cite{KOMA} oder lokal auf deiner Festplatte im \enquote{doc} Verzeichnis deiner MiKTeX Distribution findest (z.\,B. unter c:\textbackslash texmf\textbackslash doc\textbackslash latex\textbackslash koma-script).
+Wie du diese Optionen bei der Dokumentklasse setzt, findest du in Kapitel~\ref{sec:globaleoptionen}. Weitere Informationen zu diesen Optionen findest du im \enquote{scrguide}, welchen du in \cite{KOMA} oder lokal auf deiner Festplatte im \enquote{doc} Verzeichnis deiner MiKTeX"=Distribution findest (z.\,B. unter C:\textbackslash texmf\textbackslash doc\textbackslash latex\textbackslash koma-script).
 
 \subsection{Zeilenumbrüche}
 \index{Formatieren!Zeilenumbrueche@Zeilenumbrüche}
 \index{Zeilenumbruch}
 
-Einen einfachen Zeilenumbruch kannst du mit einem doppelten Backslash erzeugen. Dabei wird die Zeile genau an dieser Stelle umbrochen. Zeilenumbrüche sollten nur in speziellen Fällen verwendet werden, wie z.,B. bei Adressen, in Tabellen oder ähnlichen Situationen.
+Einen einfachen Zeilenumbruch kannst du mit einem doppelten Backslash erzeugen. Dabei wird die Zeile genau an dieser Stelle umbrochen. Zeilenumbrüche sollten nur in speziellen Fällen verwendet werden, wie z.\,B. bei Adressen, in Tabellen oder ähnlichen Situationen.
 
 \begin{lstlisting}
 Hans Muster \\
@@ -91,7 +91,7 @@ Mustergasse 12 \\
 	\item \texttt{\textbackslash subparagraph\{Unter-Absatz\}}
 \end{enumerate}
 
-Der Befehl \texttt{\textbackslash chapter} existiert nur in den Dokumentklassen \enquote{scrbook} und \enquote{scrreprt}. Weiterhin gibt es noch den Befehl \texttt{\textbackslash part}. Mehr zu Dokumentklassen findest du in Kapitel \ref{sec:dokumentklassen}.
+Der Befehl \texttt{\textbackslash chapter} existiert nur in den Dokumentklassen \enquote{scrbook} und \enquote{scrreprt}. Weiterhin gibt es noch den Befehl \texttt{\textbackslash part}. Mehr zu Dokumentklassen findest du in Kapitel~\ref{sec:dokumentklassen}.
 
 Zu jedem Überschriftstyp existiert noch eine Form mit einem \enquote{*}:
 
@@ -132,7 +132,7 @@ Beachte auch dass fetter Text die Aufmerksamkeit des Lesers auf die so markierte
 \section{Listen und Aufzählungen}
 \index{Listen|(}\index{Aufzaehlungen@Aufzählungen|(}
 
-Es gibt verschiedenste Listen und Aufzählungen in \DMLLaTeX. Hier zeige ich die Wichtigsten davon:
+Es gibt verschiedenste Listen und Aufzählungen in \DMLLaTeX. Hier zeige ich die wichtigsten davon:
 
 \subsection{Einfache Aufzählung}
 \index{Aufzaehlungen@Aufzählungen!einfache}\index{Einfache Aufzaehlung@einfache Aufzählung}
@@ -179,7 +179,7 @@ Und so sieht das ganze fertig aus:
 \subsection{Verschachtelte Aufzählungen}
 \index{Aufzaehlungen@Aufzählungen!verschachtelte}\index{Verschachtelte Aufzaehlungen@verschachtelte Aufzählungen}
 
-Diese Aufzählungstypen lassen sich natürlich beliebig verschachteln:
+Diese Aufzählungstypen lassen sich beliebig verschachteln:
 
 \begin{lstlisting}
 \begin{enumerate}

--- a/chapters/titlepage.tex
+++ b/chapters/titlepage.tex
@@ -14,15 +14,15 @@
 		Diplomarbeit mit \DMLLaTeX\\
 		\vspace{1cm}
 		\large
-		\textbf{Version 1.12}\\
-		20.4.2008\\
+		\textbf{Version 1.12.1}\\
+		2020-07-25\\
 		\vspace{2cm}
 		Tobias Erbsland \enquote*{tobias.erbsland\,\emph{at}\,profzone.ch}\\
 		Andreas Nitsch \enquote*{akki\,\emph{at}\,akki-n.de}\\
 	\end{center}
 	\normalsize
 	\vfill
-	Copyright (c)  2002--2008  Tobias Erbsland, Andreas Nitsch
+	Copyright (c) 2002--2008 Tobias Erbsland, Andreas Nitsch
 
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.2

--- a/chapters/vorwort.tex
+++ b/chapters/vorwort.tex
@@ -15,32 +15,32 @@
 \enquote{Es gibt Alternativen zu WYSIWYG\footnote{What You See Is What You Get} Textverarbeitungen}.
 \end{quote}
 
-Während einer Diplomarbeit steht man meist unter einem starken Zeitdruck. Einen großen Teil der Zeit, welche du zur Verfügung hast, brauchst du, um die Dokumentation zu deiner Arbeit zu schreiben. Viele Studenten begehen den Fehler, dass sie sich keine Gedanken darüber machen, welches die geeignetste Anwendung für ein solch meist umfangreiches Dokument ist. So verschwenden sie einen großen Teil der Zeit mit ärgerlichen Programmabstürzen, falschen Seitennummerierungen und unerklärlichen Effekten, die sich nicht beheben lassen\footnote{Ich beziehe mich in diesen Ausführungen auf Programme wie z.\,B. Microsoft Word. Selbstverständlich gibt es sehr gute WYSIWYG Programme. Es existieren auch sehr gute WYSIWYG-Erweiterungen und -Editoren, welche \DMLLaTeX \ Code direkt grafisch darstellen.}.
+Während einer Abschlussarbeit steht man meist unter starkem Zeitdruck. Einen großen Teil der Zeit, welche du zur Verfügung hast, brauchst du, um die Dokumentation zu deiner Arbeit zu schreiben. Es lohnt sich, Gedanken darüber machen, welches die geeignetste Anwendung für ein solch meist umfangreiches Dokument ist. Denn man möchte schließlich vermeiden, seine Zeit mit ärgerlichen Programmabstürzen, falschen Seitennummerierungen und unerklärlichen Effekten, die sich nicht beheben lassen, zu verschwenden.\footnote{Ich beziehe mich in diesen Ausführungen auf Programme wie z.\,B. Microsoft Word. Selbstverständlich gibt es sehr gute WYSIWYG Programme. Es existieren auch sehr gute WYSIWYG-Erweiterungen und -Editoren, welche \DMLLaTeX"=Code direkt grafisch darstellen.}
 
 Meistens beginnen die Probleme ab einer bestimmten Größe des Dokuments, aber dann ist es oft zu spät, um die Anwendung zu wechseln.
 
-Ich möchte dir daher einen einfachen Weg aufzeigen, wie du deine Diplomarbeit oder die Dokumentation dazu mit \DMLLaTeX\footnote{Ausgesprochen wird \DMLLaTeX \ \enquote{laa-tech}, wobei das \emph{X}, der große griechische Buchstabe \emph{Chi}, ein stimmloser uvularer Frikativ ist, also wie in \enquote{ach} oder \enquote{Loch} ausgesprochen werden sollte. Da dieser Laut nach einem \emph{e} jedoch für Deutschsprachler ungewohnt ist, wird im deutschsprachigen Raum oft anstelle dessen ein stimmloser palataler Frikativ, also ein Ich-Laut wie in \enquote{Technik} verwendet.} erstellen kannst. Dabei beschreibe ich detailliert den Weg von der Installation einer \DMLLaTeX-Distribution unter Windows bis zum ersten lauffähigen Dokument. Weiter beschreibt dieses Dokument häufig benötigte Formatierungen und Themen, welche im Zusammenhang mit einer Diplomarbeit wichtig sind.
+Ich möchte dir daher einen einfachen Weg aufzeigen, wie du deine Abschlussarbeit oder die Dokumentation dazu mit \DMLLaTeX\footnote{Ausgesprochen wird \DMLLaTeX{} \enquote{laa-tech}, wobei das \emph{X}, der große griechische Buchstabe \emph{Chi}, ein stimmloser uvularer Frikativ ist, also wie in \enquote{ach} oder \enquote{Loch} ausgesprochen werden sollte. Da dieser Laut nach einem \emph{e} jedoch für Deutschsprachler ungewohnt ist, wird im deutschsprachigen Raum oft anstelle dessen ein stimmloser palataler Frikativ, also ein Ich-Laut wie in \enquote{Technik} verwendet.} erstellen kannst. Dabei beschreibe ich detailliert den Weg von der Installation einer \DMLLaTeX-Distribution bis zum ersten lauf\/fähigen Dokument (schwerpunktmäßig unter Windows). Weiter beschreibt dieses Dokument häufig benötigte Formatierungen und Themen, welche im Zusammenhang mit Abschlussarbeiten wie einer Diplomarbeit wichtig sind.
 
-\section{Ortho- und Typografie}
+\section{Zu diesem Dokument}
 
-Das vorliegende Dokument richtet sich nach den Rechtschreibregeln, welche durch die Reform der deutschen Rechtschreibung von 1996 in der Fassung von 2004 festgelegt sind. Ferner sind im Schweizer Stil die hier verwendeten Anführungszeichen \enquote{ und } (im Gegensatz zu den deutschen "`~und~"').
+Im vorliegenden Dokument werden Anführungszeichen im Schweizer Stil \enquote{ und } verwendet (im Gegensatz zu den deutschen "`~und~"').
 
-\section{Unterstützung, Vorschläge und Ergänzungen} %Unterstützung hierhin verschoben, weil einiges doppelt anzugeben gewesen wäre 
+\subsection{Unterstützung, Vorschläge und Ergänzungen} %Unterstützung hierhin verschoben, weil einiges doppelt anzugeben gewesen wäre 
 
-Ich schreibe dieses Dokument in der Hoffnung, dass es nützlich ist. Daher freue ich mich natürlich über Fehlerberichtigungen und Ergänzungen, welche in das Konzept dieses Dokuments passen -- falls du mir gerne helfen möchtest, findest du einige Anregungen und weitere Details im Abschnitt \ref{sec:hilfe-gesucht}.
+Ich schreibe dieses Dokument in der Hoffnung, dass es nützlich ist. Daher freue ich mich natürlich über Fehlerberichtigungen und Ergänzungen, welche in das Konzept dieses Dokuments passen. Falls du mir gerne helfen möchtest, findest du einige Anregungen und weitere Details im Abschnitt \ref{sec:hilfe-gesucht}.
 
-Bevor du Fehler meldest oder Vorschläge machst, solltest du kontrollieren, ob du die neueste Version dieses Dokuments hast, welche du unter dem URL
+Bevor du Fehler meldest oder Vorschläge machst, solltest du kontrollieren, ob du die neueste Version dieses Dokuments hast, welche du unter
 
-\href{https://github.com/texdoc/diplomarbeit-mit-latex}{\textbf{https://github.com/texdoc/diplomarbeit-mit-latex}}\footnote{Die ursprüngliche Website http://drzoom.ch/project/dml/ und die Mailingliste existieren nicht mehr.}
+\urlindent[\footnote{Die ursprüngliche Website http://drzoom.ch/project/dml/ und die Mailingliste existieren nicht mehr.}]{https://github.com/texdoc/diplomarbeit-mit-latex}
 
 findest. Dort kannst du auch Fragen stellen und Vorschläge machen.
 
-\section{Dank}
+\subsection{Dank}
 
 Folgende Personen haben mich beim Schreiben dieses Dokumentes unterstützt. Ich danke ihnen für Korrekturen, Verbesserungen und Kritik. Dadurch ist diese Anleitung wesentlich lesenswerter geworden. 
 
 \begin{itemize}
-	\item \enquote{Seth}
+	\item \enquote{seth}
 	\item Christian Faulhammer
 	\item Thomas Holenstein
 	\item David Kastrup
@@ -51,7 +51,7 @@ Folgende Personen haben mich beim Schreiben dieses Dokumentes unterstützt. Ich d
 	\item Uwe Bieling
 \end{itemize}
 
-\section{Ausstehende und durchgeführte Änderungen an diesem Dokument}
+\subsection{Ausstehende und durchgeführte Änderungen an diesem Dokument}
 
 In Anhang \ref{sec:aendeungen} befindet sich eine Liste, welche die Änderungen zwischen den verschiedenen Versionen dieses Dokuments aufzeigt. Daneben findest du eine Liste mit ausstehenden Fragen und Änderungen im Anhang \ref{sec:ausstehendes}.
 

--- a/chapters/vorwort.tex
+++ b/chapters/vorwort.tex
@@ -29,11 +29,11 @@ Das vorliegende Dokument richtet sich nach den Rechtschreibregeln, welche durch 
 
 Ich schreibe dieses Dokument in der Hoffnung, dass es nützlich ist. Daher freue ich mich natürlich über Fehlerberichtigungen und Ergänzungen, welche in das Konzept dieses Dokuments passen -- falls du mir gerne helfen möchtest, findest du einige Anregungen und weitere Details im Abschnitt \ref{sec:hilfe-gesucht}.
 
-Bevor du Fehler meldest oder Vorschläge machst, solltest du kontrollieren, ob du die neueste Version dieses Dokuments hast, welche du immer unter dem folgenden URL findest:
+Bevor du Fehler meldest oder Vorschläge machst, solltest du kontrollieren, ob du die neueste Version dieses Dokuments hast, welche du unter dem URL
 
-\href{http://drzoom.ch/project/dml/}{\textbf{http://drzoom.ch/project/dml/}}
+\href{https://github.com/texdoc/diplomarbeit-mit-latex}{\textbf{https://github.com/texdoc/diplomarbeit-mit-latex}}\footnote{Die ursprüngliche Website http://drzoom.ch/project/dml/ und die Mailingliste existieren nicht mehr.}
 
-Du solltest dich auch in der Mailingliste Eintragen. Dort kannst du Fragen stellen und Vorschläge machen. Den Link zum Eintragen in die Mailingliste findest du auch auf der Webseite.
+findest. Dort kannst du auch Fragen stellen und Vorschläge machen.
 
 \section{Dank}
 


### PR DESCRIPTION
* links aktualisiert
* typos
* einfuehrende kapitel etwas aktualisiert; obsolete hinweise geloescht oder ersetzt (z.b. nach der alten rechtschreibung kraeht kein hahn mehr)
* warnings, errors und over-/underfull boxes behoben (ausser an einer stelle, wo eine tabelle absichtlich ueber den rand hinausragt, um genau das zu zeigen)
* nicht ganz so verbreitetes font-package entfernt
* notwendige fehlende bib-file angaben ergaenzt
* package tabularx hinzugenommen
* versionsnummer (patch level) erhoeht auf 1.12.1, da hauptsaechlich bugfixes und kein wesentlich neuer inhalt

fixes #1 