### PR TITLE
Add GitHub super linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,55 @@
+---
+###########################
+###########################
+## Linter GitHub Actions ##
+###########################
+###########################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+on:
+    push:
+    branches-ignore: [master]
+    # Remove the line above to run when pushing to master
+    pull_request:
+    branches: [master]
+
+###############
+# Set the Job #
+###############
+jobs:
+    build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+        ##########################
+        # Checkout the code base #
+        ##########################
+        - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+            # Full git history is needed to get a proper list of changed files within `super-linter`
+            fetch-depth: 0
+
+        ################################
+        # Run Linter against code base #
+        ################################
+        - name: Lint Code Base
+        uses: github/super-linter@v3
+        env:
+            VALIDATE_ALL_CODEBASE: false
+            DEFAULT_BRANCH: master
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,7 +25,7 @@ on:
 # Set the Job #
 ###############
 jobs:
-    build:
+  build:
     # Name the Job
     name: Lint Code Base
     # Set the agent to run on
@@ -39,17 +39,17 @@ jobs:
         # Checkout the code base #
         ##########################
         - name: Checkout Code
-        uses: actions/checkout@v2
-        with:
-            # Full git history is needed to get a proper list of changed files within `super-linter`
-            fetch-depth: 0
+          uses: actions/checkout@v2
+          with:
+              # Full git history is needed to get a proper list of changed files within `super-linter`
+              fetch-depth: 0
 
         ################################
         # Run Linter against code base #
         ################################
         - name: Lint Code Base
-        uses: github/super-linter@v3
-        env:
-            VALIDATE_ALL_CODEBASE: false
-            DEFAULT_BRANCH: master
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          uses: github/super-linter@v3
+          env:
+              VALIDATE_ALL_CODEBASE: false
+              DEFAULT_BRANCH: master
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,10 +15,10 @@ name: Lint Code Base
 # Start the job on all push #
 #############################
 on:
-    push:
+  push:
     branches-ignore: [master]
     # Remove the line above to run when pushing to master
-    pull_request:
+  pull_request:
     branches: [master]
 
 ###############


### PR DESCRIPTION
I like linting. GitHub [introduced super-linter](https://github.blog/2020-06-18-introducing-github-super-linter-one-linter-to-rule-them-all/)

For us, [ChkTex](https://www.nongnu.org/chktex/) and [markdown-lint](https://github.com/igorshubovych/markdownlint-cli#readme) are interesting. Let's see how it works.